### PR TITLE
refactor: add domain events, AccessCode VO, and fix KafkaProducer lifecycle

### DIFF
--- a/src/deps/index.ts
+++ b/src/deps/index.ts
@@ -59,34 +59,22 @@ export async function initKakfaConsumers(config: AppConfig) {
   const invoiceProducer = new KafkaProducer(producer, KAFKA_TOPICS.INVOICES);
 
   // Commands
-  const createInvoiceCommand = new CreateInvoiceCommand(
-    coreAdapter,
-    invoiceRepository,
-    invoiceProducer,
-  );
-  const signInvoiceCommand = new SignInvoiceCommand(
-    sealifyAdapter,
-    invoiceRepository,
-    invoiceProducer,
-  );
-  const sendInvoiceCommand = new SendInvoiceCommand(
-    sriValidationAdapter,
-    invoiceRepository,
-    invoiceProducer,
-  );
+  const createInvoiceCommand = new CreateInvoiceCommand(coreAdapter, invoiceRepository);
+  const signInvoiceCommand = new SignInvoiceCommand(sealifyAdapter, invoiceRepository);
+  const sendInvoiceCommand = new SendInvoiceCommand(sriValidationAdapter, invoiceRepository);
   const authorizeInvoiceCommand = new AuthorizeInvoiceCommand(
     sriAuthorizationAdapter,
     invoiceRepository,
-    invoiceProducer,
   );
 
   // Handlers
-  const orderMessageHandler = new OrderMessageHandler(createInvoiceCommand);
+  const orderMessageHandler = new OrderMessageHandler(createInvoiceCommand, invoiceProducer);
   const invoiceMessageHandler = new InvoiceMessageHandler(
     invoiceRepository,
     signInvoiceCommand,
     sendInvoiceCommand,
     authorizeInvoiceCommand,
+    invoiceProducer,
   );
 
   // Consumer
@@ -105,5 +93,7 @@ export async function initKakfaConsumers(config: AppConfig) {
     },
   );
 
-  return { kafkaConsumer };
+  await invoiceProducer.connect();
+
+  return { kafkaConsumer, kafkaProducer: invoiceProducer };
 }

--- a/src/modules/invoice/app/commands/authorize-invoice.ts
+++ b/src/modules/invoice/app/commands/authorize-invoice.ts
@@ -1,28 +1,23 @@
 import { Invoice, InvoiceStatus } from '../../domain/invoice';
-import { MessageProducer, SriAuthorizationPort } from '../../domain/ports';
+import { SriAuthorizationPort } from '../../domain/ports';
 import { InvoiceRepository } from '../../domain/repository';
 import { AuthorizationVoucherStatus } from '../../domain/voucher';
-import { InvoiceMessage } from './create-invoice';
 
 export class AuthorizeInvoiceCommand {
   constructor(
     private sriAuthorizationPort: SriAuthorizationPort,
     private invoiceRepository: InvoiceRepository,
-    private messageProducer: MessageProducer<InvoiceMessage>,
   ) {}
 
   async execute(invoice: Invoice): Promise<void> {
-    const authorizationVoucher = await this.sriAuthorizationPort.authorizeXml(invoice.accessCode);
+    const authorizationVoucher = await this.sriAuthorizationPort.authorizeXml(
+      invoice.accessCode.value,
+    );
     const invoiceStatus =
       authorizationVoucher.status === AuthorizationVoucherStatus.AUTHORIZED
         ? InvoiceStatus.AUTHORIZED
         : InvoiceStatus.REJECTED;
     invoice.addStatusHistory(invoiceStatus, new Date(), authorizationVoucher.messages.join(' >> '));
     await this.invoiceRepository.updateInvoice(invoice);
-    await this.messageProducer.sendMessage({
-      id: invoice.id,
-      orderId: invoice.orderId,
-      status: invoice.status,
-    });
   }
 }

--- a/src/modules/invoice/app/commands/create-invoice.ts
+++ b/src/modules/invoice/app/commands/create-invoice.ts
@@ -1,43 +1,28 @@
+import { AccessCode } from '../../domain/access-code';
 import { Invoice, InvoiceStatus } from '../../domain/invoice';
-import { CorePort, MessageProducer } from '../../domain/ports';
+import { CorePort } from '../../domain/ports';
 import { InvoiceRepository } from '../../domain/repository';
-
-export interface OrderMessage {
-  id: number;
-  accessCode: string;
-  sequence: string;
-}
-
-export interface InvoiceMessage {
-  id: string;
-  orderId: string;
-  status: InvoiceStatus;
-}
+import { OrderMessage } from '../../infra/messaging/schemas';
 
 export class CreateInvoiceCommand {
   constructor(
     private corePort: CorePort,
     private invoiceRepository: InvoiceRepository,
-    private messageProducer: MessageProducer<InvoiceMessage>,
   ) {}
 
-  async execute(message: OrderMessage): Promise<void> {
+  async execute(message: OrderMessage): Promise<Invoice> {
     const order = await this.corePort.retrieveOrder(message.id);
     const xml = order.generateInvoiceXml();
     const invoice = new Invoice(
       undefined,
       order.id.toString(),
-      order.accessCode,
+      AccessCode.create(order.accessCode),
       InvoiceStatus.CREATED,
       order.sriConfig.signature,
       xml,
     );
     invoice.addStatusHistory(InvoiceStatus.CREATED, new Date(), 'XML created');
     await this.invoiceRepository.createInvoice(invoice);
-    await this.messageProducer.sendMessage({
-      id: invoice.id,
-      orderId: invoice.orderId,
-      status: invoice.status,
-    });
+    return invoice;
   }
 }

--- a/src/modules/invoice/app/commands/send-invoice.ts
+++ b/src/modules/invoice/app/commands/send-invoice.ts
@@ -1,14 +1,12 @@
 import { Invoice, InvoiceStatus } from '../../domain/invoice';
-import { MessageProducer, SriValidationPort } from '../../domain/ports';
+import { SriValidationPort } from '../../domain/ports';
 import { InvoiceRepository } from '../../domain/repository';
 import { ValidationVoucherStatus } from '../../domain/voucher';
-import { InvoiceMessage } from './create-invoice';
 
 export class SendInvoiceCommand {
   constructor(
     private sriValidationPort: SriValidationPort,
     private invoiceRepository: InvoiceRepository,
-    private messageProducer: MessageProducer<InvoiceMessage>,
   ) {}
 
   async execute(invoice: Invoice): Promise<void> {
@@ -19,10 +17,5 @@ export class SendInvoiceCommand {
         : InvoiceStatus.REJECTED;
     invoice.addStatusHistory(invoiceStatus, new Date(), validationVoucher.messages.join(' >> '));
     await this.invoiceRepository.updateInvoice(invoice);
-    await this.messageProducer.sendMessage({
-      id: invoice.id,
-      orderId: invoice.orderId,
-      status: invoice.status,
-    });
   }
 }

--- a/src/modules/invoice/app/commands/sign-invoice.ts
+++ b/src/modules/invoice/app/commands/sign-invoice.ts
@@ -1,13 +1,11 @@
 import { Invoice, InvoiceStatus } from '../../domain/invoice';
-import { MessageProducer, SealifyPort } from '../../domain/ports';
+import { SealifyPort } from '../../domain/ports';
 import { InvoiceRepository } from '../../domain/repository';
-import { InvoiceMessage } from './create-invoice';
 
 export class SignInvoiceCommand {
   constructor(
     private sealifyPort: SealifyPort,
     private invoiceRepository: InvoiceRepository,
-    private messageProducer: MessageProducer<InvoiceMessage>,
   ) {}
 
   async execute(invoice: Invoice): Promise<void> {
@@ -15,10 +13,5 @@ export class SignInvoiceCommand {
     invoice.xml = signedXml;
     invoice.addStatusHistory(InvoiceStatus.SIGNED, new Date(), 'XML signed');
     await this.invoiceRepository.updateInvoice(invoice);
-    await this.messageProducer.sendMessage({
-      id: invoice.id,
-      orderId: invoice.orderId,
-      status: invoice.status,
-    });
   }
 }

--- a/src/modules/invoice/app/handlers/invoice-message.handler.ts
+++ b/src/modules/invoice/app/handlers/invoice-message.handler.ts
@@ -1,7 +1,9 @@
+import { InvoiceDomainEvent } from '../../domain/events';
 import { InvoiceStatus } from '../../domain/invoice';
+import { MessageProducer } from '../../domain/ports';
 import { InvoiceRepository } from '../../domain/repository';
+import { InvoiceMessage } from '../../infra/messaging/schemas';
 import { AuthorizeInvoiceCommand } from '../commands/authorize-invoice';
-import { InvoiceMessage } from '../commands/create-invoice';
 import { SendInvoiceCommand } from '../commands/send-invoice';
 import { SignInvoiceCommand } from '../commands/sign-invoice';
 import { logger } from '#/shared/logger';
@@ -12,17 +14,18 @@ export class InvoiceMessageHandler {
     private signInvoiceCommand: SignInvoiceCommand,
     private sendInvoiceCommand: SendInvoiceCommand,
     private authorizeInvoiceCommand: AuthorizeInvoiceCommand,
+    private messageProducer: MessageProducer<InvoiceDomainEvent>,
   ) {}
 
   async handle(message: InvoiceMessage): Promise<void> {
-    const invoice = await this.invoiceRepository.getInvoiceById(message.id);
+    const invoice = await this.invoiceRepository.getInvoiceById(message.invoiceId);
     if (!invoice) {
-      logger.warn({ invoiceId: message.id }, 'Invoice not found');
+      logger.warn({ invoiceId: message.invoiceId }, 'Invoice not found');
       return;
     }
 
     if ([InvoiceStatus.REJECTED, InvoiceStatus.AUTHORIZED].includes(invoice.status)) {
-      logger.warn({ invoiceId: message.id }, 'Invoice already processed');
+      logger.warn({ invoiceId: message.invoiceId }, 'Invoice already processed');
       return;
     }
 
@@ -32,6 +35,10 @@ export class InvoiceMessageHandler {
       await this.sendInvoiceCommand.execute(invoice);
     } else if (invoice.status === InvoiceStatus.SENT) {
       await this.authorizeInvoiceCommand.execute(invoice);
+    }
+
+    for (const event of invoice.pullEvents()) {
+      await this.messageProducer.sendMessage(event);
     }
   }
 }

--- a/src/modules/invoice/app/handlers/order-message.handler.ts
+++ b/src/modules/invoice/app/handlers/order-message.handler.ts
@@ -1,9 +1,18 @@
-import { CreateInvoiceCommand, OrderMessage } from '../commands/create-invoice';
+import { InvoiceDomainEvent } from '../../domain/events';
+import { MessageProducer } from '../../domain/ports';
+import { CreateInvoiceCommand } from '../commands/create-invoice';
+import { OrderMessage } from '../../infra/messaging/schemas';
 
 export class OrderMessageHandler {
-  constructor(private createInvoiceCommand: CreateInvoiceCommand) {}
+  constructor(
+    private createInvoiceCommand: CreateInvoiceCommand,
+    private messageProducer: MessageProducer<InvoiceDomainEvent>,
+  ) {}
 
   async handle(message: OrderMessage): Promise<void> {
-    await this.createInvoiceCommand.execute(message);
+    const invoice = await this.createInvoiceCommand.execute(message);
+    for (const event of invoice.pullEvents()) {
+      await this.messageProducer.sendMessage(event);
+    }
   }
 }

--- a/src/modules/invoice/domain/access-code.ts
+++ b/src/modules/invoice/domain/access-code.ts
@@ -1,0 +1,20 @@
+export class AccessCode {
+  private static readonly PATTERN = /^\d{49}$/;
+
+  private constructor(public readonly value: string) {}
+
+  static create(value: string): AccessCode {
+    if (!AccessCode.PATTERN.test(value)) {
+      throw new Error(`Invalid access code: must be exactly 49 digits, got "${value}"`);
+    }
+    return new AccessCode(value);
+  }
+
+  toString(): string {
+    return this.value;
+  }
+
+  equals(other: AccessCode): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/invoice/domain/events.ts
+++ b/src/modules/invoice/domain/events.ts
@@ -1,0 +1,49 @@
+export enum InvoiceStatus {
+  CREATED = 'created',
+  SIGNED = 'signed',
+  SENT = 'sent',
+  AUTHORIZED = 'authorized',
+  REJECTED = 'rejected',
+}
+
+interface BaseInvoiceEvent {
+  invoiceId: string;
+  orderId: string;
+  status: InvoiceStatus;
+  occurredAt: Date;
+}
+
+export interface InvoiceCreated extends BaseInvoiceEvent {
+  type: 'InvoiceCreated';
+}
+
+export interface InvoiceSigned extends BaseInvoiceEvent {
+  type: 'InvoiceSigned';
+}
+
+export interface InvoiceSent extends BaseInvoiceEvent {
+  type: 'InvoiceSent';
+}
+
+export interface InvoiceAuthorized extends BaseInvoiceEvent {
+  type: 'InvoiceAuthorized';
+}
+
+export interface InvoiceRejected extends BaseInvoiceEvent {
+  type: 'InvoiceRejected';
+}
+
+export type InvoiceDomainEvent =
+  | InvoiceCreated
+  | InvoiceSigned
+  | InvoiceSent
+  | InvoiceAuthorized
+  | InvoiceRejected;
+
+export const STATUS_EVENT_TYPE: Record<InvoiceStatus, InvoiceDomainEvent['type']> = {
+  [InvoiceStatus.CREATED]: 'InvoiceCreated',
+  [InvoiceStatus.SIGNED]: 'InvoiceSigned',
+  [InvoiceStatus.SENT]: 'InvoiceSent',
+  [InvoiceStatus.AUTHORIZED]: 'InvoiceAuthorized',
+  [InvoiceStatus.REJECTED]: 'InvoiceRejected',
+};

--- a/src/modules/invoice/domain/invoice.ts
+++ b/src/modules/invoice/domain/invoice.ts
@@ -1,12 +1,8 @@
 import { v4 as uuidv4 } from 'uuid';
+import { AccessCode } from './access-code';
+import { InvoiceDomainEvent, InvoiceStatus, STATUS_EVENT_TYPE } from './events';
 
-export enum InvoiceStatus {
-  CREATED = 'created',
-  SIGNED = 'signed',
-  SENT = 'sent',
-  AUTHORIZED = 'authorized',
-  REJECTED = 'rejected',
-}
+export { InvoiceStatus } from './events';
 
 export class InvoiceStatusHistory {
   constructor(
@@ -17,10 +13,12 @@ export class InvoiceStatusHistory {
 }
 
 export class Invoice {
+  private _domainEvents: InvoiceDomainEvent[] = [];
+
   constructor(
     public id: string = uuidv4(),
     public orderId: string,
-    public accessCode: string,
+    public accessCode: AccessCode,
     public status: InvoiceStatus,
     public signatureId: string,
     public xml: string,
@@ -30,5 +28,18 @@ export class Invoice {
   addStatusHistory(status: InvoiceStatus, date = new Date(), description?: string) {
     this.status = status;
     this.statusHistory.push(new InvoiceStatusHistory(status, date, description));
+    this._domainEvents.push({
+      type: STATUS_EVENT_TYPE[status],
+      invoiceId: this.id,
+      orderId: this.orderId,
+      status,
+      occurredAt: date,
+    } as InvoiceDomainEvent);
+  }
+
+  pullEvents(): InvoiceDomainEvent[] {
+    const events = [...this._domainEvents];
+    this._domainEvents = [];
+    return events;
   }
 }

--- a/src/modules/invoice/infra/messaging/kafka-producer.ts
+++ b/src/modules/invoice/infra/messaging/kafka-producer.ts
@@ -8,13 +8,19 @@ export class KafkaProducer<T> implements MessageProducer<T> {
     private topic: string,
   ) {}
 
-  async sendMessage(message: T): Promise<void> {
+  async connect(): Promise<void> {
     await this.producer.connect();
+  }
+
+  async disconnect(): Promise<void> {
+    await this.producer.disconnect();
+  }
+
+  async sendMessage(message: T): Promise<void> {
     await this.producer.send({
       topic: this.topic,
       messages: [{ value: JSON.stringify(message) }],
     });
     logger.info({ topic: this.topic, message }, 'Message sent');
-    await this.producer.disconnect();
   }
 }

--- a/src/modules/invoice/infra/messaging/schemas.ts
+++ b/src/modules/invoice/infra/messaging/schemas.ts
@@ -96,14 +96,26 @@ export type SealInvoiceResponse = z.infer<typeof SealInvoiceResponseSchema>;
 
 // --- Kafka Message Schemas ---
 
-export const OrderMessageSchema = z.object({
-  id: z.number(),
-  access_code: z.string(),
-  sequence: z.string(),
-});
+export const OrderMessageSchema = z
+  .object({
+    id: z.number(),
+    access_code: z.string(),
+    sequence: z.string(),
+  })
+  .transform((data) => ({
+    id: data.id,
+    accessCode: data.access_code,
+    sequence: data.sequence,
+  }));
+
+export type OrderMessage = z.infer<typeof OrderMessageSchema>;
 
 export const InvoiceMessageSchema = z.object({
-  id: z.string(),
+  type: z.string(),
+  invoiceId: z.string(),
   orderId: z.string(),
   status: z.nativeEnum(InvoiceStatus),
+  occurredAt: z.coerce.date(),
 });
+
+export type InvoiceMessage = z.infer<typeof InvoiceMessageSchema>;

--- a/src/modules/invoice/infra/persistence/invoice.mapper.ts
+++ b/src/modules/invoice/infra/persistence/invoice.mapper.ts
@@ -1,3 +1,4 @@
+import { AccessCode } from '../../domain/access-code';
 import { Invoice, InvoiceStatus, InvoiceStatusHistory } from '../../domain/invoice';
 
 export interface InvoiceRecord {
@@ -18,7 +19,7 @@ export function toInvoiceRecord(entity: Invoice): InvoiceRecord {
   return {
     id: entity.id,
     orderId: entity.orderId,
-    accessCode: entity.accessCode,
+    accessCode: entity.accessCode.value,
     status: entity.status,
     signatureId: entity.signatureId,
     xml: entity.xml,
@@ -34,7 +35,7 @@ export function fromInvoiceRecord(record: InvoiceRecord): Invoice {
   return new Invoice(
     record.id,
     record.orderId,
-    record.accessCode,
+    AccessCode.create(record.accessCode),
     record.status as InvoiceStatus,
     record.signatureId,
     record.xml,

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,12 +10,13 @@ const main = async () => {
     serviceName: config.serviceName,
     environment: config.environment,
   });
-  const { kafkaConsumer } = await initKakfaConsumers(config);
+  const { kafkaConsumer, kafkaProducer } = await initKakfaConsumers(config);
   await kafkaConsumer.start();
 
   const shutdown = async () => {
     logger.info('Shutting down...');
-    //await kafkaConsumer.stop();
+    await kafkaConsumer.stop();
+    await kafkaProducer.disconnect();
     process.exit(0);
   };
 


### PR DESCRIPTION
- Introduce domain events (InvoiceCreated, InvoiceSigned, etc.) emitted automatically by Invoice.addStatusHistory() via pullEvents() pattern
  - Add AccessCode value object with 49-digit validation
  - Move MessageProducer dependency from commands to handlers, decoupling business logic from messaging infrastructure
  - Fix KafkaProducer to connect once at startup and disconnect on shutdown instead of reconnecting on every message
  - Replace manual DTO interfaces with Zod-inferred types and add transform to OrderMessageSchema for snake_case → camelCase conversion
  - Wire graceful shutdown for both consumer and producer