### PR TITLE
chore: add import sorting, unused import removal, and fix explicit any types

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,8 @@ import prettierConfig from 'eslint-config-prettier';
 import prettierPlugin from 'eslint-plugin-prettier';
 import tsParser from '@typescript-eslint/parser';
 import tsPlugin from '@typescript-eslint/eslint-plugin';
+import simpleImportSort from 'eslint-plugin-simple-import-sort';
+import unusedImports from 'eslint-plugin-unused-imports';
 
 export default [
   {
@@ -18,6 +20,8 @@ export default [
     plugins: {
       '@typescript-eslint': tsPlugin,
       prettier: prettierPlugin,
+      'simple-import-sort': simpleImportSort,
+      'unused-imports': unusedImports,
     },
     rules: {
       ...js.configs.recommended.rules,
@@ -25,6 +29,15 @@ export default [
       'prettier/prettier': 'error',
       'no-dupe-class-members': 'off',
       '@typescript-eslint/no-dupe-class-members': 'error',
+      'simple-import-sort/imports': 'error',
+      'simple-import-sort/exports': 'error',
+      '@typescript-eslint/no-unused-vars': 'off',
+      'no-unused-vars': 'off',
+      'unused-imports/no-unused-imports': 'error',
+      'unused-imports/no-unused-vars': [
+        'warn',
+        { vars: 'all', varsIgnorePattern: '^_', args: 'after-used', argsIgnorePattern: '^_' },
+      ],
     },
   },
   prettierConfig,

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "eslint": "^9.22.0",
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-prettier": "^5.2.3",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
+    "eslint-plugin-unused-imports": "^4.4.1",
     "globals": "^16.0.0",
     "pettier": "^1.1.0",
     "prettier": "^3.5.3",

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,29 +1,29 @@
-import { AppConfig } from '#/config';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { Kafka } from 'kafkajs';
-import { SoapClient } from '#/shared/infra/soap-client';
 
+import { AppConfig } from '#/config';
+import { AuthorizeInvoiceCommand } from '#/modules/invoice/app/commands/authorize-invoice';
+import { CreateInvoiceCommand } from '#/modules/invoice/app/commands/create-invoice';
+import { SendInvoiceCommand } from '#/modules/invoice/app/commands/send-invoice';
+import { SignInvoiceCommand } from '#/modules/invoice/app/commands/sign-invoice';
+import { InvoiceMessageHandler } from '#/modules/invoice/app/handlers/invoice-message.handler';
+import { OrderMessageHandler } from '#/modules/invoice/app/handlers/order-message.handler';
 import { CoreAdapter } from '#/modules/invoice/infra/adapters/core.adapter';
 import { SealifyAdapter } from '#/modules/invoice/infra/adapters/sealify.adapter';
-import { SriValidationAdapter } from '#/modules/invoice/infra/adapters/sri-validation.adapter';
 import { SriAuthorizationAdapter } from '#/modules/invoice/infra/adapters/sri-authorization.adapter';
-import { DynamoInvoiceRepository } from '#/modules/invoice/infra/persistence/dynamo-invoice.repository';
-import { KafkaProducer } from '#/modules/invoice/infra/messaging/kafka-producer';
+import { SriValidationAdapter } from '#/modules/invoice/infra/adapters/sri-validation.adapter';
 import { InvoiceKafkaConsumer } from '#/modules/invoice/infra/messaging/kafka-consumer';
+import { KafkaProducer } from '#/modules/invoice/infra/messaging/kafka-producer';
 import {
+  InvoiceMessageSchema,
+  OrderMessageSchema,
   OrderResponseSchema,
   SealInvoiceResponseSchema,
-  OrderMessageSchema,
-  InvoiceMessageSchema,
 } from '#/modules/invoice/infra/messaging/schemas';
 import { KAFKA_TOPICS } from '#/modules/invoice/infra/messaging/topics';
-import { CreateInvoiceCommand } from '#/modules/invoice/app/commands/create-invoice';
-import { SignInvoiceCommand } from '#/modules/invoice/app/commands/sign-invoice';
-import { SendInvoiceCommand } from '#/modules/invoice/app/commands/send-invoice';
-import { AuthorizeInvoiceCommand } from '#/modules/invoice/app/commands/authorize-invoice';
-import { OrderMessageHandler } from '#/modules/invoice/app/handlers/order-message.handler';
-import { InvoiceMessageHandler } from '#/modules/invoice/app/handlers/invoice-message.handler';
+import { DynamoInvoiceRepository } from '#/modules/invoice/infra/persistence/dynamo-invoice.repository';
+import { SoapClient } from '#/shared/infra/soap-client';
 
 export async function createContainer(config: AppConfig) {
   // Infra clients

--- a/src/modules/invoice/app/handlers/invoice-message.handler.ts
+++ b/src/modules/invoice/app/handlers/invoice-message.handler.ts
@@ -1,3 +1,5 @@
+import { logger } from '#/shared/logger';
+
 import { InvoiceDomainEvent } from '../../domain/events';
 import { InvoiceStatus } from '../../domain/invoice';
 import { MessageProducer } from '../../domain/ports';
@@ -6,7 +8,6 @@ import { InvoiceMessage } from '../../infra/messaging/schemas';
 import { AuthorizeInvoiceCommand } from '../commands/authorize-invoice';
 import { SendInvoiceCommand } from '../commands/send-invoice';
 import { SignInvoiceCommand } from '../commands/sign-invoice';
-import { logger } from '#/shared/logger';
 
 export class InvoiceMessageHandler {
   constructor(

--- a/src/modules/invoice/app/handlers/order-message.handler.ts
+++ b/src/modules/invoice/app/handlers/order-message.handler.ts
@@ -1,7 +1,7 @@
 import { InvoiceDomainEvent } from '../../domain/events';
 import { MessageProducer } from '../../domain/ports';
-import { CreateInvoiceCommand } from '../commands/create-invoice';
 import { OrderMessage } from '../../infra/messaging/schemas';
+import { CreateInvoiceCommand } from '../commands/create-invoice';
 
 export class OrderMessageHandler {
   constructor(

--- a/src/modules/invoice/domain/invoice.ts
+++ b/src/modules/invoice/domain/invoice.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+
 import { AccessCode } from './access-code';
 import { InvoiceDomainEvent, InvoiceStatus, STATUS_EVENT_TYPE } from './events';
 

--- a/src/modules/invoice/domain/order.ts
+++ b/src/modules/invoice/domain/order.ts
@@ -88,8 +88,8 @@ export class Order {
     public tax: number,
     public total: number,
     public status: string,
-    public file: any | null,
-    public errors: Record<string, any>,
+    public file: unknown,
+    public errors: Record<string, unknown>,
     public customer: Customer,
   ) {}
 
@@ -143,10 +143,33 @@ function getInvoiceData(order: Order) {
         propina: 0,
         importeTotal: order.total,
         moneda: 'DOLAR',
-        pagos: { pago: [] as any[] },
+        pagos: {
+          pago: [] as { formaPago: string; total: number; plazo: number; unidadTiempo: string }[],
+        },
       },
-      detalles: { detalle: [] as any[] },
-      infoAdicional: { campoAdicional: [] as any[] },
+      detalles: {
+        detalle: [] as {
+          codigoPrincipal: string;
+          codigoAuxiliar: string;
+          descripcion: string;
+          cantidad: number;
+          precioUnitario: number;
+          descuento: number;
+          precioTotalSinImpuesto: number;
+          impuestos: {
+            impuesto: {
+              codigo: number;
+              codigoPorcentaje: number;
+              tarifa: number;
+              baseImponible: number;
+              valor: number;
+            }[];
+          };
+        }[],
+      },
+      infoAdicional: {
+        campoAdicional: [] as { '@nombre': string; '#text': string }[],
+      },
     },
   };
 

--- a/src/modules/invoice/domain/ports.ts
+++ b/src/modules/invoice/domain/ports.ts
@@ -1,5 +1,5 @@
-import { AuthorizationVoucher, ValidationVoucher } from './voucher';
 import { Order } from './order';
+import { AuthorizationVoucher, ValidationVoucher } from './voucher';
 
 export interface CorePort {
   retrieveOrder(orderId: number): Promise<Order>;

--- a/src/modules/invoice/infra/adapters/core.adapter.ts
+++ b/src/modules/invoice/infra/adapters/core.adapter.ts
@@ -1,11 +1,13 @@
-import { BaseHttpClient } from '#/shared/infra/http-client';
-import { Endpoint } from '#/shared/types';
-import { logger } from '#/shared/logger';
-import { CorePort } from '../../domain/ports';
-import { Order } from '../../domain/order';
-import { OrderResponse } from '../messaging/schemas';
-import { mapOrderToDomain } from '../mappers/order.mapper';
 import { ZodSchema } from 'zod';
+
+import { BaseHttpClient } from '#/shared/infra/http-client';
+import { logger } from '#/shared/logger';
+import { Endpoint } from '#/shared/types';
+
+import { Order } from '../../domain/order';
+import { CorePort } from '../../domain/ports';
+import { mapOrderToDomain } from '../mappers/order.mapper';
+import { OrderResponse } from '../messaging/schemas';
 
 export class CoreAdapter extends BaseHttpClient implements CorePort {
   constructor(

--- a/src/modules/invoice/infra/adapters/sealify.adapter.ts
+++ b/src/modules/invoice/infra/adapters/sealify.adapter.ts
@@ -1,8 +1,10 @@
+import { ZodSchema } from 'zod';
+
 import { BaseHttpClient } from '#/shared/infra/http-client';
 import { Endpoint } from '#/shared/types';
+
 import { SealifyPort } from '../../domain/ports';
 import { SealInvoiceResponse } from '../messaging/schemas';
-import { ZodSchema } from 'zod';
 
 export class SealifyAdapter extends BaseHttpClient implements SealifyPort {
   constructor(

--- a/src/modules/invoice/infra/adapters/sri-authorization.adapter.ts
+++ b/src/modules/invoice/infra/adapters/sri-authorization.adapter.ts
@@ -1,20 +1,19 @@
 import { SoapClient } from '#/shared/infra/soap-client';
+
 import { SriAuthorizationPort } from '../../domain/ports';
 import { AuthorizationVoucher } from '../../domain/voucher';
 import {
-  mapAuthorizationVoucherToDomain,
   AuthorizationVoucherResponseDTO,
+  mapAuthorizationVoucherToDomain,
 } from '../mappers/sri-authorization.mapper';
 
 export class SriAuthorizationAdapter implements SriAuthorizationPort {
   constructor(private authorizationClient: SoapClient) {}
 
   async authorizeXml(code: string): Promise<AuthorizationVoucher> {
-    const response = await this.authorizationClient.callMethod('autorizacionComprobante', {
+    const response = (await this.authorizationClient.callMethod('autorizacionComprobante', {
       claveAccesoComprobante: code,
-    });
-    return mapAuthorizationVoucherToDomain(
-      response.RespuestaAutorizacionComprobante as AuthorizationVoucherResponseDTO,
-    );
+    })) as { RespuestaAutorizacionComprobante: AuthorizationVoucherResponseDTO };
+    return mapAuthorizationVoucherToDomain(response.RespuestaAutorizacionComprobante);
   }
 }

--- a/src/modules/invoice/infra/adapters/sri-validation.adapter.ts
+++ b/src/modules/invoice/infra/adapters/sri-validation.adapter.ts
@@ -1,4 +1,5 @@
 import { SoapClient } from '#/shared/infra/soap-client';
+
 import { SriValidationPort } from '../../domain/ports';
 import { ValidationVoucher } from '../../domain/voucher';
 import {
@@ -11,9 +12,9 @@ export class SriValidationAdapter implements SriValidationPort {
 
   async validateXml(xml: string): Promise<ValidationVoucher> {
     xml = Buffer.from(xml, 'utf-8').toString('base64');
-    const response = await this.validateClient.callMethod('validarComprobante', { xml });
-    return mapValidationVoucherToDomain(
-      response.RespuestaRecepcionComprobante as ReceiptVoucherResponseDTO,
-    );
+    const response = (await this.validateClient.callMethod('validarComprobante', {
+      xml,
+    })) as { RespuestaRecepcionComprobante: ReceiptVoucherResponseDTO };
+    return mapValidationVoucherToDomain(response.RespuestaRecepcionComprobante);
   }
 }

--- a/src/modules/invoice/infra/messaging/kafka-consumer.ts
+++ b/src/modules/invoice/infra/messaging/kafka-consumer.ts
@@ -1,17 +1,18 @@
 import { Consumer } from 'kafkajs';
-import { logger } from '#/shared/logger';
-import { BaseKafkaConsumer } from '#/shared/infra/kafka';
 import { ZodSchema } from 'zod';
 
+import { BaseKafkaConsumer } from '#/shared/infra/kafka';
+import { logger } from '#/shared/logger';
+
 interface MessageProcessor {
-  handle(message: any): Promise<void>;
+  handle(message: unknown): Promise<void>;
 }
 
 export class InvoiceKafkaConsumer extends BaseKafkaConsumer {
   constructor(
     consumer: Consumer,
     topics: string[],
-    private processors: Record<string, { handler: MessageProcessor; validator: ZodSchema<any> }>,
+    private processors: Record<string, { handler: MessageProcessor; validator: ZodSchema }>,
   ) {
     super(consumer, topics);
   }

--- a/src/modules/invoice/infra/messaging/kafka-producer.ts
+++ b/src/modules/invoice/infra/messaging/kafka-producer.ts
@@ -1,5 +1,7 @@
 import { Producer } from 'kafkajs';
+
 import { logger } from '#/shared/logger';
+
 import { MessageProducer } from '../../domain/ports';
 
 export class KafkaProducer<T> implements MessageProducer<T> {

--- a/src/modules/invoice/infra/messaging/schemas.ts
+++ b/src/modules/invoice/infra/messaging/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import { InvoiceStatus } from '../../domain/invoice';
 
 // --- Order Response (from Core API) ---

--- a/src/modules/invoice/infra/persistence/dynamo-invoice.repository.ts
+++ b/src/modules/invoice/infra/persistence/dynamo-invoice.repository.ts
@@ -1,7 +1,8 @@
 import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+
 import { Invoice } from '../../domain/invoice';
 import { InvoiceRepository } from '../../domain/repository';
-import { InvoiceRecord, fromInvoiceRecord, toInvoiceRecord } from './invoice.mapper';
+import { fromInvoiceRecord, InvoiceRecord, toInvoiceRecord } from './invoice.mapper';
 
 export class DynamoInvoiceRepository implements InvoiceRepository {
   constructor(

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
-import { createContainer } from './container';
 import { initLogger, logger } from '#/shared/logger';
+
 import loadConfig from './config';
+import { createContainer } from './container';
 
 const main = async () => {
   const config = await loadConfig();

--- a/src/shared/infra/http-client.ts
+++ b/src/shared/infra/http-client.ts
@@ -19,10 +19,18 @@ export class BaseHttpClient {
     return this.axiosInstance.get(url, config);
   }
 
-  async post<T>(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
+  async post<T>(
+    url: string,
+    data?: unknown,
+    config?: AxiosRequestConfig,
+  ): Promise<AxiosResponse<T>> {
     return this.axiosInstance.post(url, data, config);
   }
-  async put<T>(url: string, data?: any, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {
+  async put<T>(
+    url: string,
+    data?: unknown,
+    config?: AxiosRequestConfig,
+  ): Promise<AxiosResponse<T>> {
     return this.axiosInstance.put(url, data, config);
   }
 

--- a/src/shared/infra/kafka.ts
+++ b/src/shared/infra/kafka.ts
@@ -1,4 +1,5 @@
 import { Consumer } from 'kafkajs';
+
 import { logger } from '../logger';
 
 export abstract class BaseKafkaConsumer {

--- a/src/shared/infra/soap-client.ts
+++ b/src/shared/infra/soap-client.ts
@@ -1,9 +1,19 @@
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { soap } = require('strong-soap');
 
+type SoapMethod = (
+  args: Record<string, unknown>,
+  callback: (err: Error | null, result: unknown) => void,
+) => void;
+
+interface SoapClientInstance {
+  describe(): Record<string, unknown>;
+  [methodName: string]: SoapMethod | (() => Record<string, unknown>);
+}
+
 export class SoapClient {
   private wsdlUrl: string;
-  private client: any | null = null;
+  private client: SoapClientInstance | null = null;
 
   constructor(wsdlUrl: string) {
     this.wsdlUrl = wsdlUrl;
@@ -12,29 +22,29 @@ export class SoapClient {
   private async initClient(): Promise<void> {
     if (this.client) return;
 
-    this.client = await new Promise((resolve, reject) => {
-      soap.createClient(this.wsdlUrl, {}, (err: any, client: any) => {
+    this.client = await new Promise<SoapClientInstance>((resolve, reject) => {
+      soap.createClient(this.wsdlUrl, {}, (err: Error | null, client: SoapClientInstance) => {
         if (err) return reject(err);
         resolve(client);
       });
     });
   }
 
-  async describe(): Promise<any> {
+  async describe(): Promise<Record<string, unknown>> {
     await this.initClient();
-    return this.client.describe();
+    return this.client!.describe();
   }
 
-  async callMethod(methodName: string, args: any): Promise<any> {
+  async callMethod(methodName: string, args: Record<string, unknown>): Promise<unknown> {
     await this.initClient();
 
     return new Promise((resolve, reject) => {
-      const method = this.client[methodName];
+      const method = this.client![methodName];
       if (typeof method !== 'function') {
         return reject(new Error(`Método '${methodName}' no encontrado en el cliente SOAP.`));
       }
 
-      method(args, (err: any, result: any) => {
+      (method as SoapMethod)(args, (err: Error | null, result: unknown) => {
         if (err) return reject(err);
         resolve(result);
       });


### PR DESCRIPTION
  Configure eslint-plugin-simple-import-sort and eslint-plugin-unused-imports
  to enforce import ordering and auto-remove unused imports. Replace all
  explicit  types with  or proper typed alternatives to resolve
  no-explicit-any lint errors.