### PR TITLE
refactor: improve logger config, reduce noise, and add traceability

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,7 +5,6 @@ export interface AppConfig {
   serviceVersion: string;
   logger: {
     level: string;
-    prettyPrint: boolean;
   };
   externalServices: {
     core: Endpoint;

--- a/src/config/local.ts
+++ b/src/config/local.ts
@@ -5,7 +5,6 @@ export default {
   serviceVersion: '1.0.0',
   logger: {
     level: 'debug',
-    prettyPrint: true,
   },
   externalServices: {
     core: {

--- a/src/config/production.ts
+++ b/src/config/production.ts
@@ -1,6 +1,11 @@
 import { AppConfig } from './index';
 
 export default {
+  serviceName: 'sri-integrator',
+  serviceVersion: '1.0.0',
+  logger: {
+    level: 'info',
+  },
   externalServices: {
     core: {
       host: 'http://localhost:8000',

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,6 +1,7 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
-import { Kafka } from 'kafkajs';
+import { Kafka, logLevel as KafkaLogLevel } from 'kafkajs';
+import pino from 'pino';
 
 import { AppConfig } from '#/config';
 import { AuthorizeInvoiceCommand } from '#/modules/invoice/app/commands/authorize-invoice';
@@ -24,12 +25,28 @@ import {
 import { KAFKA_TOPICS } from '#/modules/invoice/infra/messaging/topics';
 import { DynamoInvoiceRepository } from '#/modules/invoice/infra/persistence/dynamo-invoice.repository';
 import { SoapClient } from '#/shared/infra/soap-client';
+import { logger } from '#/shared/logger';
 
 export async function createContainer(config: AppConfig) {
   // Infra clients
+  const kafkaLogLevelMap: Record<number, string> = {
+    [KafkaLogLevel.ERROR]: 'error',
+    [KafkaLogLevel.WARN]: 'warn',
+    [KafkaLogLevel.INFO]: 'info',
+    [KafkaLogLevel.DEBUG]: 'debug',
+    [KafkaLogLevel.NOTHING]: 'silent',
+  };
+
   const kafka = new Kafka({
     clientId: 'sri-integrator',
     brokers: config.kafka.brokers,
+    logCreator:
+      () =>
+      ({ level, log }) => {
+        const pinoLevel = (kafkaLogLevelMap[level] ?? 'info') as pino.Level;
+        const { message, ...extra } = log;
+        logger[pinoLevel]({ ...extra, kafka: true }, message);
+      },
   });
   const consumer = kafka.consumer({ groupId: config.kafka.groupId });
   const producer = kafka.producer();

--- a/src/modules/invoice/app/commands/authorize-invoice.ts
+++ b/src/modules/invoice/app/commands/authorize-invoice.ts
@@ -1,3 +1,5 @@
+import { logger } from '#/shared/logger';
+
 import { Invoice, InvoiceStatus } from '../../domain/invoice';
 import { SriAuthorizationPort } from '../../domain/ports';
 import { InvoiceRepository } from '../../domain/repository';
@@ -10,6 +12,10 @@ export class AuthorizeInvoiceCommand {
   ) {}
 
   async execute(invoice: Invoice): Promise<void> {
+    logger.info(
+      { invoiceId: invoice.id, accessCode: invoice.accessCode.value },
+      'Authorizing invoice',
+    );
     const authorizationVoucher = await this.sriAuthorizationPort.authorizeXml(
       invoice.accessCode.value,
     );
@@ -19,5 +25,9 @@ export class AuthorizeInvoiceCommand {
         : InvoiceStatus.REJECTED;
     invoice.addStatusHistory(invoiceStatus, new Date(), authorizationVoucher.messages.join(' >> '));
     await this.invoiceRepository.updateInvoice(invoice);
+    logger.info(
+      { invoiceId: invoice.id, status: invoiceStatus },
+      'Invoice authorization completed',
+    );
   }
 }

--- a/src/modules/invoice/app/commands/send-invoice.ts
+++ b/src/modules/invoice/app/commands/send-invoice.ts
@@ -1,3 +1,5 @@
+import { logger } from '#/shared/logger';
+
 import { Invoice, InvoiceStatus } from '../../domain/invoice';
 import { SriValidationPort } from '../../domain/ports';
 import { InvoiceRepository } from '../../domain/repository';
@@ -10,6 +12,7 @@ export class SendInvoiceCommand {
   ) {}
 
   async execute(invoice: Invoice): Promise<void> {
+    logger.info({ invoiceId: invoice.id }, 'Sending invoice to SRI');
     const validationVoucher = await this.sriValidationPort.validateXml(invoice.xml);
     const invoiceStatus =
       validationVoucher.status === ValidationVoucherStatus.ACCEPTED
@@ -17,5 +20,6 @@ export class SendInvoiceCommand {
         : InvoiceStatus.REJECTED;
     invoice.addStatusHistory(invoiceStatus, new Date(), validationVoucher.messages.join(' >> '));
     await this.invoiceRepository.updateInvoice(invoice);
+    logger.info({ invoiceId: invoice.id, status: invoiceStatus }, 'Invoice sent to SRI');
   }
 }

--- a/src/modules/invoice/app/commands/sign-invoice.ts
+++ b/src/modules/invoice/app/commands/sign-invoice.ts
@@ -1,3 +1,5 @@
+import { logger } from '#/shared/logger';
+
 import { Invoice, InvoiceStatus } from '../../domain/invoice';
 import { SealifyPort } from '../../domain/ports';
 import { InvoiceRepository } from '../../domain/repository';
@@ -9,9 +11,11 @@ export class SignInvoiceCommand {
   ) {}
 
   async execute(invoice: Invoice): Promise<void> {
+    logger.info({ invoiceId: invoice.id }, 'Signing invoice');
     const signedXml = await this.sealifyPort.sealInvoice(invoice.xml, invoice.signatureId);
     invoice.xml = signedXml;
     invoice.addStatusHistory(InvoiceStatus.SIGNED, new Date(), 'XML signed');
     await this.invoiceRepository.updateInvoice(invoice);
+    logger.info({ invoiceId: invoice.id }, 'Invoice signed');
   }
 }

--- a/src/modules/invoice/infra/adapters/core.adapter.ts
+++ b/src/modules/invoice/infra/adapters/core.adapter.ts
@@ -21,8 +21,8 @@ export class CoreAdapter extends BaseHttpClient implements CorePort {
     const response = await this.get(`/api/invoice/${orderId}/`);
     const parsedResponse = this.validator.safeParse(response.data);
     if (parsedResponse.error) {
-      logger.error({ error: parsedResponse.error.stack }, 'Invalid order response');
-      throw new Error(parsedResponse.error.errors.join(', '));
+      logger.error({ orderId, issues: parsedResponse.error.issues }, 'Invalid order response');
+      throw new Error(parsedResponse.error.issues.map((i) => i.message).join(', '));
     }
     return mapOrderToDomain(parsedResponse.data);
   }

--- a/src/modules/invoice/infra/messaging/kafka-consumer.ts
+++ b/src/modules/invoice/infra/messaging/kafka-consumer.ts
@@ -27,8 +27,8 @@ export class InvoiceKafkaConsumer extends BaseKafkaConsumer {
     const result = processor.validator.safeParse(JSON.parse(message));
 
     if (!result.success) {
-      logger.error({ error: result.error.stack }, 'Invalid message schema');
-      throw new Error(result.error.errors.join(', '));
+      logger.error({ topic, issues: result.error.issues }, 'Invalid message schema');
+      throw new Error(result.error.issues.map((i) => i.message).join(', '));
     }
 
     await processor.handler.handle(result.data);

--- a/src/modules/invoice/infra/messaging/kafka-producer.ts
+++ b/src/modules/invoice/infra/messaging/kafka-producer.ts
@@ -23,6 +23,6 @@ export class KafkaProducer<T> implements MessageProducer<T> {
       topic: this.topic,
       messages: [{ value: JSON.stringify(message) }],
     });
-    logger.info({ topic: this.topic, message }, 'Message sent');
+    logger.debug({ topic: this.topic }, 'Message sent');
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ const main = async () => {
 
   const { consumer, producer } = await createContainer(config);
   await consumer.start();
+  logger.info({ env: config.environment }, 'Application started');
 
   const shutdown = async () => {
     logger.info('Shutting down...');

--- a/src/shared/infra/kafka.ts
+++ b/src/shared/infra/kafka.ts
@@ -20,8 +20,12 @@ export abstract class BaseKafkaConsumer {
     await this.consumer.run({
       eachMessage: async ({ topic, message }) => {
         if (message.value) {
-          logger.info({ topic, message: message.value.toString() }, 'Kafka message received');
-          await this.handleMessage(topic, message.value.toString());
+          const value = message.value.toString();
+          logger.debug(
+            { topic, key: message.key?.toString(), size: value.length },
+            'Kafka message received',
+          );
+          await this.handleMessage(topic, value);
         }
       },
     });

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -3,23 +3,23 @@ import pino from 'pino';
 let logger: pino.Logger = pino({ level: 'silent' });
 
 export function initLogger(config: { level: string; serviceName: string; environment: string }) {
-  logger = pino(
-    {
-      level: config.level,
-      base: {
-        service: config.serviceName,
-        environment: config.environment,
-      },
-      timestamp: pino.stdTimeFunctions.isoTime,
-    },
-    pino.transport({
-      target: 'pino-pretty',
-      options: {
-        colorize: true,
-        translateTime: 'SYS:standard',
+  const isLocal = config.environment === 'local';
+
+  logger = pino({
+    level: config.level,
+    base: isLocal ? undefined : { service: config.serviceName, environment: config.environment },
+    timestamp: pino.stdTimeFunctions.isoTime,
+    ...(isLocal && {
+      transport: {
+        target: 'pino-pretty',
+        options: {
+          colorize: true,
+          translateTime: 'SYS:standard',
+        },
       },
     }),
-  );
+  });
+
   return logger;
 }
 


### PR DESCRIPTION
  - Configure pino-pretty only for local env, raw JSON for production
  - Route KafkaJS internal logs through pino for consistent formatting
  - Complete missing production config (serviceName, logger level)
  - Remove unused prettyPrint config option
  - Reduce Kafka log noise: log only metadata instead of full message body
  - Fix Zod error logging to use issues instead of non-existent stack
  - Add startup log and traceability logs in invoice commands