### PR TITLE
chore: migrate kafka client from kafkajs to @confluentinc/kafka-javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@aws-sdk/lib-dynamodb": "^3.1014.0",
     "@aws-sdk/util-dynamodb": "^3.996.2",
     "axios": "^1.13.6",
-    "kafkajs": "^2.2.4",
+    "@confluentinc/kafka-javascript": "^1.8.0",
     "luxon": "^3.7.2",
     "pino": "^9.14.0",
     "pino-pretty": "^13.1.3",

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,7 +1,6 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
-import { Kafka, logLevel as KafkaLogLevel } from 'kafkajs';
-import pino from 'pino';
+import { KafkaJS } from '@confluentinc/kafka-javascript';
 
 import { AppConfig } from '#/config';
 import { AuthorizeInvoiceCommand } from '#/modules/invoice/app/commands/authorize-invoice';
@@ -25,33 +24,27 @@ import {
 import { KAFKA_TOPICS } from '#/modules/invoice/infra/messaging/topics';
 import { DynamoInvoiceRepository } from '#/modules/invoice/infra/persistence/dynamo-invoice.repository';
 import { SoapClient } from '#/shared/infra/soap-client';
-import { logger } from '#/shared/logger';
 
 export async function createContainer(config: AppConfig) {
   // Infra clients
-  const kafkaLogLevelMap: Record<number, string> = {
-    [KafkaLogLevel.ERROR]: 'error',
-    [KafkaLogLevel.WARN]: 'warn',
-    [KafkaLogLevel.INFO]: 'info',
-    [KafkaLogLevel.DEBUG]: 'debug',
-    [KafkaLogLevel.NOTHING]: 'silent',
-  };
-
-  const kafka = new Kafka({
-    clientId: 'sri-integrator',
-    brokers: config.kafka.brokers,
-    logCreator:
-      () =>
-      ({ level, log }) => {
-        const pinoLevel = (kafkaLogLevelMap[level] ?? 'info') as pino.Level;
-        const { message, ...extra } = log;
-        logger[pinoLevel]({ ...extra, kafka: true }, message);
-      },
+  const kafka = new KafkaJS.Kafka({
+    kafkaJS: {
+      brokers: config.kafka.brokers,
+      clientId: 'sri-integrator',
+      logLevel: KafkaJS.logLevel.INFO,
+    },
   });
-  const consumer = kafka.consumer({ groupId: config.kafka.groupId });
+  const consumer = kafka.consumer({
+    kafkaJS: {
+      groupId: config.kafka.groupId,
+    },
+  });
   const producer = kafka.producer({
-    idempotent: true,
-    maxInFlightRequests: 5,
+    kafkaJS: {
+      acks: -1,
+    },
+    'enable.idempotence': true,
+    'max.in.flight.requests.per.connection': 5,
   });
 
   const ddbClient = new DynamoDBClient({ region: config.aws.region });

--- a/src/modules/invoice/infra/messaging/kafka-consumer.ts
+++ b/src/modules/invoice/infra/messaging/kafka-consumer.ts
@@ -1,4 +1,4 @@
-import { Consumer } from 'kafkajs';
+import { KafkaJS } from '@confluentinc/kafka-javascript';
 import { ZodSchema } from 'zod';
 
 import { BaseKafkaConsumer } from '#/shared/infra/kafka';
@@ -10,7 +10,7 @@ interface MessageProcessor {
 
 export class InvoiceKafkaConsumer extends BaseKafkaConsumer {
   constructor(
-    consumer: Consumer,
+    consumer: KafkaJS.Consumer,
     topics: string[],
     private processors: Record<string, { handler: MessageProcessor; validator: ZodSchema }>,
   ) {

--- a/src/modules/invoice/infra/messaging/kafka-producer.ts
+++ b/src/modules/invoice/infra/messaging/kafka-producer.ts
@@ -1,4 +1,4 @@
-import { Producer } from 'kafkajs';
+import { KafkaJS } from '@confluentinc/kafka-javascript';
 
 import { logger } from '#/shared/logger';
 
@@ -6,7 +6,7 @@ import { MessageProducer } from '../../domain/ports';
 
 export class KafkaProducer<T> implements MessageProducer<T> {
   constructor(
-    private producer: Producer,
+    private producer: KafkaJS.Producer,
     private topic: string,
   ) {}
 

--- a/src/shared/infra/kafka.ts
+++ b/src/shared/infra/kafka.ts
@@ -1,10 +1,10 @@
-import { Consumer } from 'kafkajs';
+import { KafkaJS } from '@confluentinc/kafka-javascript';
 
 import { logger } from '../logger';
 
 export abstract class BaseKafkaConsumer {
   constructor(
-    private consumer: Consumer,
+    private consumer: KafkaJS.Consumer,
     private topics: string[],
   ) {}
 
@@ -12,10 +12,7 @@ export abstract class BaseKafkaConsumer {
 
   async start(): Promise<void> {
     await this.consumer.connect();
-
-    for (const topic of this.topics) {
-      await this.consumer.subscribe({ topic, fromBeginning: false });
-    }
+    await this.consumer.subscribe({ topics: this.topics });
 
     await this.consumer.run({
       eachMessage: async ({ topic, partition, message }) => {
@@ -45,7 +42,6 @@ export abstract class BaseKafkaConsumer {
   }
 
   async stop(): Promise<void> {
-    await this.consumer.stop();
     await this.consumer.disconnect();
   }
 }


### PR DESCRIPTION

  Replace kafkajs with the official Confluent Kafka client for better
  performance and native librdkafka support. Update consumer, producer,
  and container configuration to use the new KafkaJS compatibility API.