### PR TITLE
feat: load signing certificate from S3 via DynamoDB lookup

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -16,7 +16,7 @@ export interface AppConfig {
     sriQueryWsdl: string;
   };
   signing: {
-    p12Path: string;
+    p12Id: string;
     p12Password: string;
   };
   kafka: {

--- a/src/config/local.ts
+++ b/src/config/local.ts
@@ -38,7 +38,7 @@ export default {
     },
   },
   signing: {
-    p12Path: process.env.SIGNING_P12_PATH || './certs/signing.p12',
+    p12Id: process.env.SIGNING_P12_ID || '',
     p12Password: process.env.SIGNING_P12_PASSWORD || '',
   },
   timezone: 'America/Guayaquil',

--- a/src/config/production.ts
+++ b/src/config/production.ts
@@ -37,7 +37,7 @@ export default {
     },
   },
   signing: {
-    p12Path: process.env.SIGNING_P12_PATH!,
+    p12Id: process.env.SIGNING_P12_ID!,
     p12Password: process.env.SIGNING_P12_PASSWORD!,
   },
   timezone: 'America/Guayaquil',

--- a/src/container.ts
+++ b/src/container.ts
@@ -35,7 +35,6 @@ import {
 } from '#/modules/invoice/infra/messaging/schemas';
 import { KAFKA_TOPICS } from '#/modules/invoice/infra/messaging/topics';
 import { DynamoInvoiceRepository } from '#/modules/invoice/infra/persistence/dynamo-invoice.repository';
-import { P12Reader } from '#/modules/invoice/infra/signing/p12-reader';
 import { XadesSigner } from '#/modules/invoice/infra/signing/xades-signer';
 import { createHttpServer } from '#/shared/infra/http-server';
 import { SoapClient } from '#/shared/infra/soap-client';
@@ -83,12 +82,22 @@ export async function createContainer(config: AppConfig) {
     docClient,
     config.aws.dynamoDb.tables.invoices,
   );
+  const certificateRepository = new DynamoCertificateRepository(
+    docClient,
+    config.aws.dynamoDb.tables.certificates,
+  );
 
   // Adapters
+  const s3Storage = new S3StorageAdapter(s3Client, config.aws.s3.bucket, config.aws.endpoint);
   const coreAdapter = new CoreAdapter(config.externalServices.core, OrderResponseSchema);
-  const p12Reader = new P12Reader(config.signing.p12Path, config.signing.p12Password);
   const xadesSigner = new XadesSigner(config.timezone);
-  const localSignerAdapter = new LocalSignerAdapter(p12Reader, xadesSigner);
+  const localSignerAdapter = new LocalSignerAdapter(
+    certificateRepository,
+    s3Storage,
+    xadesSigner,
+    config.signing.p12Id,
+    config.signing.p12Password,
+  );
   const sriValidationAdapter = new SriValidationAdapter(validationClient);
   const sriAuthorizationAdapter = new SriAuthorizationAdapter(authorizationClient);
 
@@ -136,12 +145,7 @@ export async function createContainer(config: AppConfig) {
   );
 
   // Certificate module
-  const certificateRepository = new DynamoCertificateRepository(
-    docClient,
-    config.aws.dynamoDb.tables.certificates,
-  );
   const p12Parser = new P12ParserAdapter();
-  const s3Storage = new S3StorageAdapter(s3Client, config.aws.s3.bucket, config.aws.endpoint);
 
   const uploadCertificateCommand = new UploadCertificateCommand(
     p12Parser,

--- a/src/modules/certificate/domain/ports.ts
+++ b/src/modules/certificate/domain/ports.ts
@@ -12,5 +12,6 @@ export interface P12ParserPort {
 
 export interface FileStoragePort {
   upload(key: string, content: Buffer, contentType: string): Promise<string>;
+  download(key: string): Promise<Buffer>;
   delete(key: string): Promise<void>;
 }

--- a/src/modules/certificate/infra/adapters/s3-storage.adapter.ts
+++ b/src/modules/certificate/infra/adapters/s3-storage.adapter.ts
@@ -1,4 +1,9 @@
-import { DeleteObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
 
 import { FileStoragePort } from '../../domain/ports';
 
@@ -23,6 +28,22 @@ export class S3StorageAdapter implements FileStoragePort {
       return `${this.endpoint}/${this.bucket}/${key}`;
     }
     return `https://${this.bucket}.s3.amazonaws.com/${key}`;
+  }
+
+  async download(key: string): Promise<Buffer> {
+    const response = await this.s3Client.send(
+      new GetObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+      }),
+    );
+
+    if (!response.Body) {
+      throw new Error(`Empty response body for S3 key: ${key}`);
+    }
+
+    const byteArray = await response.Body.transformToByteArray();
+    return Buffer.from(byteArray);
   }
 
   async delete(key: string): Promise<void> {

--- a/src/modules/invoice/infra/adapters/local-signer.adapter.ts
+++ b/src/modules/invoice/infra/adapters/local-signer.adapter.ts
@@ -1,16 +1,42 @@
+import { FileStoragePort } from '#/modules/certificate/domain/ports';
+import { CertificateRepository } from '#/modules/certificate/domain/repository';
+
 import { InvoiceSignerPort } from '../../domain/ports';
-import { P12Reader } from '../signing/p12-reader';
+import { P12Reader, SigningCredentials } from '../signing/p12-reader';
 import { XadesSigner } from '../signing/xades-signer';
 
 export class LocalSignerAdapter implements InvoiceSignerPort {
+  private credentials: SigningCredentials | null = null;
+
   constructor(
-    private readonly p12Reader: P12Reader,
+    private readonly certificateRepository: CertificateRepository,
+    private readonly fileStorage: FileStoragePort,
     private readonly xadesSigner: XadesSigner,
+    private readonly p12Id: string,
+    private readonly p12Password: string,
   ) {}
 
   async signInvoice(xml: string): Promise<string> {
-    const credentials = this.p12Reader.getCredentials();
-    console.log(credentials);
+    const credentials = await this.getCredentials();
     return this.xadesSigner.sign(xml, credentials);
+  }
+
+  private async getCredentials(): Promise<SigningCredentials> {
+    if (this.credentials) return this.credentials;
+
+    if (!this.p12Id) {
+      throw new Error('SIGNING_P12_ID environment variable is not configured');
+    }
+
+    const certificate = await this.certificateRepository.findById(this.p12Id);
+    if (!certificate) {
+      throw new Error(`Signing certificate not found: ${this.p12Id}`);
+    }
+
+    const p12Buffer = await this.fileStorage.download(certificate.s3Key);
+    const p12Reader = new P12Reader(p12Buffer, this.p12Password);
+    this.credentials = p12Reader.getCredentials();
+
+    return this.credentials;
   }
 }

--- a/src/modules/invoice/infra/signing/p12-reader.ts
+++ b/src/modules/invoice/infra/signing/p12-reader.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs';
 import * as forge from 'node-forge';
 
 export interface SigningCredentials {
@@ -42,15 +41,14 @@ export class P12Reader {
   private credentials: SigningCredentials | null = null;
 
   constructor(
-    private readonly p12Path: string,
+    private readonly p12Buffer: Buffer,
     private readonly password: string,
   ) {}
 
   getCredentials(): SigningCredentials {
     if (this.credentials) return this.credentials;
 
-    const p12Buffer = fs.readFileSync(this.p12Path);
-    const p12Der = forge.util.decode64(p12Buffer.toString('base64'));
+    const p12Der = forge.util.decode64(this.p12Buffer.toString('base64'));
     const p12Asn1 = forge.asn1.fromDer(p12Der);
     const p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, this.password);
 

--- a/src/shared/infra/kafka.ts
+++ b/src/shared/infra/kafka.ts
@@ -32,7 +32,7 @@ export abstract class BaseKafkaConsumer {
             await this.handleMessage(topic, value);
           } catch (error) {
             logger.error(
-              { topic, partition, offset: message.offset, error },
+              { topic, partition, offset: message.offset, err: error },
               'Failed to process message, skipping',
             );
           }


### PR DESCRIPTION
  Replace local filesystem P12 reading with a flow that looks up the
  certificate by ID in DynamoDB (SIGNING_P12_ID) and downloads it from S3.
  This connects the certificate module with the invoice signing pipeline,
  removing the need for a local .p12 file.

  Also fix Kafka error logging by using pino's  serializer key
  instead of  so that Error objects are properly serialized with
  message and stack trace.