### PR TITLE
refactor: extract shared P12 utility and rename signer adapter

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -23,7 +23,7 @@ import { InvoiceMessageHandler } from '#/modules/invoice/app/handlers/invoice-me
 import { OrderMessageHandler } from '#/modules/invoice/app/handlers/order-message.handler';
 import { InvoiceStatus } from '#/modules/invoice/domain/invoice';
 import { CoreAdapter } from '#/modules/invoice/infra/adapters/core.adapter';
-import { LocalSignerAdapter } from '#/modules/invoice/infra/adapters/local-signer.adapter';
+import { SignerAdapter } from '#/modules/invoice/infra/adapters/signer.adapter';
 import { SriAuthorizationAdapter } from '#/modules/invoice/infra/adapters/sri-authorization.adapter';
 import { SriValidationAdapter } from '#/modules/invoice/infra/adapters/sri-validation.adapter';
 import { InvoiceKafkaConsumer } from '#/modules/invoice/infra/messaging/kafka-consumer';
@@ -91,7 +91,7 @@ export async function createContainer(config: AppConfig) {
   const s3Storage = new S3StorageAdapter(s3Client, config.aws.s3.bucket, config.aws.endpoint);
   const coreAdapter = new CoreAdapter(config.externalServices.core, OrderResponseSchema);
   const xadesSigner = new XadesSigner(config.timezone);
-  const localSignerAdapter = new LocalSignerAdapter(
+  const signerAdapter = new SignerAdapter(
     certificateRepository,
     s3Storage,
     xadesSigner,
@@ -106,7 +106,7 @@ export async function createContainer(config: AppConfig) {
 
   // Commands
   const createInvoiceCommand = new CreateInvoiceCommand(coreAdapter, invoiceRepository);
-  const signInvoiceCommand = new SignInvoiceCommand(localSignerAdapter, invoiceRepository);
+  const signInvoiceCommand = new SignInvoiceCommand(signerAdapter, invoiceRepository);
   const sendInvoiceCommand = new SendInvoiceCommand(sriValidationAdapter, invoiceRepository);
   const authorizeInvoiceCommand = new AuthorizeInvoiceCommand(
     sriAuthorizationAdapter,

--- a/src/modules/certificate/infra/adapters/p12-parser.adapter.ts
+++ b/src/modules/certificate/infra/adapters/p12-parser.adapter.ts
@@ -1,62 +1,17 @@
-import * as forge from 'node-forge';
+import { formatRfc4514, parseP12 } from '#/shared/infra/p12';
 
 import { P12Metadata, P12ParserPort } from '../../domain/ports';
 
-const OID_SHORT_NAMES: Record<string, string> = {
-  '2.5.4.3': 'CN',
-  '2.5.4.6': 'C',
-  '2.5.4.7': 'L',
-  '2.5.4.8': 'ST',
-  '2.5.4.10': 'O',
-  '2.5.4.11': 'OU',
-  '1.2.840.113549.1.9.1': 'emailAddress',
-  '2.5.4.5': 'serialNumber',
-};
-
-function formatRfc4514(attributes: forge.pki.CertificateField[]): string {
-  return [...attributes]
-    .reverse()
-    .map((attr) => {
-      const name = attr.shortName || OID_SHORT_NAMES[attr.type as string] || attr.type;
-      return `${name}=${attr.value}`;
-    })
-    .join(',');
-}
-
 export class P12ParserAdapter implements P12ParserPort {
   parse(buffer: Buffer, password: string): P12Metadata {
-    const p12Der = forge.util.decode64(buffer.toString('base64'));
-    const p12Asn1 = forge.asn1.fromDer(p12Der);
-    const p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, password);
-
-    const certBags = p12.getBags({ bagType: forge.pki.oids.certBag });
-    const keyBags = p12.getBags({ bagType: forge.pki.oids.pkcs8ShroudedKeyBag });
-
-    const certs = certBags[forge.pki.oids.certBag]?.filter((b) => b.cert) || [];
-    const keys = keyBags[forge.pki.oids.pkcs8ShroudedKeyBag]?.filter((b) => b.key) || [];
-
-    if (certs.length === 0) throw new Error('No certificates found in P12 file');
-    if (keys.length === 0) throw new Error('No private keys found in P12 file');
-
-    let signingCert = certs[0].cert!;
-
-    for (const certBag of certs) {
-      for (const keyBag of keys) {
-        const certLocalKeyId = certBag.attributes?.localKeyId?.[0];
-        const keyLocalKeyId = keyBag.attributes?.localKeyId?.[0];
-        if (certLocalKeyId && keyLocalKeyId && certLocalKeyId === keyLocalKeyId) {
-          signingCert = certBag.cert!;
-          break;
-        }
-      }
-    }
+    const { certificate } = parseP12(buffer, password);
 
     return {
-      serialNumber: BigInt('0x' + signingCert.serialNumber).toString(),
-      subject: formatRfc4514(signingCert.subject.attributes),
-      issuer: formatRfc4514(signingCert.issuer.attributes),
-      validFrom: signingCert.validity.notBefore,
-      validTo: signingCert.validity.notAfter,
+      serialNumber: BigInt('0x' + certificate.serialNumber).toString(),
+      subject: formatRfc4514(certificate.subject.attributes),
+      issuer: formatRfc4514(certificate.issuer.attributes),
+      validFrom: certificate.validity.notBefore,
+      validTo: certificate.validity.notAfter,
     };
   }
 }

--- a/src/modules/invoice/infra/adapters/signer.adapter.ts
+++ b/src/modules/invoice/infra/adapters/signer.adapter.ts
@@ -5,7 +5,7 @@ import { InvoiceSignerPort } from '../../domain/ports';
 import { P12Reader, SigningCredentials } from '../signing/p12-reader';
 import { XadesSigner } from '../signing/xades-signer';
 
-export class LocalSignerAdapter implements InvoiceSignerPort {
+export class SignerAdapter implements InvoiceSignerPort {
   private credentials: SigningCredentials | null = null;
 
   constructor(

--- a/src/modules/invoice/infra/signing/p12-reader.ts
+++ b/src/modules/invoice/infra/signing/p12-reader.ts
@@ -1,5 +1,7 @@
 import * as forge from 'node-forge';
 
+import { formatRfc4514, parseP12 } from '#/shared/infra/p12';
+
 export interface SigningCredentials {
   certDer: Buffer;
   certBase64: string;
@@ -10,31 +12,10 @@ export interface SigningCredentials {
   exponent: Buffer;
 }
 
-const OID_SHORT_NAMES: Record<string, string> = {
-  '2.5.4.3': 'CN',
-  '2.5.4.6': 'C',
-  '2.5.4.7': 'L',
-  '2.5.4.8': 'ST',
-  '2.5.4.10': 'O',
-  '2.5.4.11': 'OU',
-  '1.2.840.113549.1.9.1': 'emailAddress',
-  '2.5.4.5': 'serialNumber',
-};
-
 function bigIntegerToBuffer(bigInt: forge.jsbn.BigInteger): Buffer {
   const hex = bigInt.toString(16);
   const paddedHex = hex.length % 2 === 0 ? hex : '0' + hex;
   return Buffer.from(paddedHex, 'hex');
-}
-
-function formatIssuerRfc4514(attributes: forge.pki.CertificateField[]): string {
-  return [...attributes]
-    .reverse()
-    .map((attr) => {
-      const name = attr.shortName || OID_SHORT_NAMES[attr.type as string] || attr.type;
-      return `${name}=${attr.value}`;
-    })
-    .join(',');
 }
 
 export class P12Reader {
@@ -48,51 +29,23 @@ export class P12Reader {
   getCredentials(): SigningCredentials {
     if (this.credentials) return this.credentials;
 
-    const p12Der = forge.util.decode64(this.p12Buffer.toString('base64'));
-    const p12Asn1 = forge.asn1.fromDer(p12Der);
-    const p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, this.password);
+    const { certificate, privateKey } = parseP12(this.p12Buffer, this.password);
 
-    const certBags = p12.getBags({ bagType: forge.pki.oids.certBag });
-    const keyBags = p12.getBags({
-      bagType: forge.pki.oids.pkcs8ShroudedKeyBag,
-    });
-
-    const certs = certBags[forge.pki.oids.certBag]?.filter((b) => b.cert) || [];
-    const keys = keyBags[forge.pki.oids.pkcs8ShroudedKeyBag]?.filter((b) => b.key) || [];
-
-    if (certs.length === 0) throw new Error('No certificates found in P12 file');
-    if (keys.length === 0) throw new Error('No private keys found in P12 file');
-
-    let signingCert = certs[0].cert!;
-    let signingKey = keys[0].key! as forge.pki.rsa.PrivateKey;
-
-    for (const certBag of certs) {
-      for (const keyBag of keys) {
-        const certLocalKeyId = certBag.attributes?.localKeyId?.[0];
-        const keyLocalKeyId = keyBag.attributes?.localKeyId?.[0];
-        if (certLocalKeyId && keyLocalKeyId && certLocalKeyId === keyLocalKeyId) {
-          signingCert = certBag.cert!;
-          signingKey = keyBag.key! as forge.pki.rsa.PrivateKey;
-          break;
-        }
-      }
-    }
-
-    const certDerBytes = forge.asn1.toDer(forge.pki.certificateToAsn1(signingCert)).getBytes();
+    const certDerBytes = forge.asn1.toDer(forge.pki.certificateToAsn1(certificate)).getBytes();
     const certDer = Buffer.from(certDerBytes, 'binary');
     const certBase64 = certDer.toString('base64');
 
-    const keyDerBytes = forge.asn1.toDer(forge.pki.privateKeyToAsn1(signingKey)).getBytes();
+    const keyDerBytes = forge.asn1.toDer(forge.pki.privateKeyToAsn1(privateKey)).getBytes();
     const keyDer = Buffer.from(keyDerBytes, 'binary');
 
-    const publicKey = signingCert.publicKey as forge.pki.rsa.PublicKey;
+    const publicKey = certificate.publicKey as forge.pki.rsa.PublicKey;
 
     this.credentials = {
       certDer,
       certBase64,
       keyDer,
-      issuerRfc4514: formatIssuerRfc4514(signingCert.issuer.attributes),
-      serialNumber: BigInt('0x' + signingCert.serialNumber).toString(),
+      issuerRfc4514: formatRfc4514(certificate.issuer.attributes),
+      serialNumber: BigInt('0x' + certificate.serialNumber).toString(),
       modulus: bigIntegerToBuffer(publicKey.n),
       exponent: bigIntegerToBuffer(publicKey.e),
     };

--- a/src/shared/infra/p12.ts
+++ b/src/shared/infra/p12.ts
@@ -1,0 +1,59 @@
+import * as forge from 'node-forge';
+
+export interface P12Container {
+  certificate: forge.pki.Certificate;
+  privateKey: forge.pki.rsa.PrivateKey;
+}
+
+const OID_SHORT_NAMES: Record<string, string> = {
+  '2.5.4.3': 'CN',
+  '2.5.4.6': 'C',
+  '2.5.4.7': 'L',
+  '2.5.4.8': 'ST',
+  '2.5.4.10': 'O',
+  '2.5.4.11': 'OU',
+  '1.2.840.113549.1.9.1': 'emailAddress',
+  '2.5.4.5': 'serialNumber',
+};
+
+export function formatRfc4514(attributes: forge.pki.CertificateField[]): string {
+  return [...attributes]
+    .reverse()
+    .map((attr) => {
+      const name = attr.shortName || OID_SHORT_NAMES[attr.type as string] || attr.type;
+      return `${name}=${attr.value}`;
+    })
+    .join(',');
+}
+
+export function parseP12(buffer: Buffer, password: string): P12Container {
+  const p12Der = forge.util.decode64(buffer.toString('base64'));
+  const p12Asn1 = forge.asn1.fromDer(p12Der);
+  const p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, password);
+
+  const certBags = p12.getBags({ bagType: forge.pki.oids.certBag });
+  const keyBags = p12.getBags({ bagType: forge.pki.oids.pkcs8ShroudedKeyBag });
+
+  const certs = certBags[forge.pki.oids.certBag]?.filter((b) => b.cert) || [];
+  const keys = keyBags[forge.pki.oids.pkcs8ShroudedKeyBag]?.filter((b) => b.key) || [];
+
+  if (certs.length === 0) throw new Error('No certificates found in P12 file');
+  if (keys.length === 0) throw new Error('No private keys found in P12 file');
+
+  let signingCert = certs[0].cert!;
+  let signingKey = keys[0].key! as forge.pki.rsa.PrivateKey;
+
+  for (const certBag of certs) {
+    for (const keyBag of keys) {
+      const certLocalKeyId = certBag.attributes?.localKeyId?.[0];
+      const keyLocalKeyId = keyBag.attributes?.localKeyId?.[0];
+      if (certLocalKeyId && keyLocalKeyId && certLocalKeyId === keyLocalKeyId) {
+        signingCert = certBag.cert!;
+        signingKey = keyBag.key! as forge.pki.rsa.PrivateKey;
+        break;
+      }
+    }
+  }
+
+  return { certificate: signingCert, privateKey: signingKey };
+}


### PR DESCRIPTION
  Extract duplicated P12 parsing logic (OID constants, RFC4514 formatting,
  certificate/key extraction) from p12-reader.ts and p12-parser.adapter.ts
  into a shared utility at src/shared/infra/p12.ts to follow DRY principle.

  Rename LocalSignerAdapter to SignerAdapter since Sealify was removed and
  there is only one InvoiceSignerPort implementation.