### PR TITLE
feat: add read-only HTTP endpoints for invoices

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -21,11 +21,13 @@ import { SendInvoiceCommand } from '#/modules/invoice/app/commands/send-invoice'
 import { SignInvoiceCommand } from '#/modules/invoice/app/commands/sign-invoice';
 import { InvoiceMessageHandler } from '#/modules/invoice/app/handlers/invoice-message.handler';
 import { OrderMessageHandler } from '#/modules/invoice/app/handlers/order-message.handler';
+import { GetInvoiceQuery, ListInvoicesQuery } from '#/modules/invoice/app/queries/invoice.queries';
 import { InvoiceStatus } from '#/modules/invoice/domain/invoice';
 import { CoreAdapter } from '#/modules/invoice/infra/adapters/core.adapter';
 import { SignerAdapter } from '#/modules/invoice/infra/adapters/signer.adapter';
 import { SriAuthorizationAdapter } from '#/modules/invoice/infra/adapters/sri-authorization.adapter';
 import { SriValidationAdapter } from '#/modules/invoice/infra/adapters/sri-validation.adapter';
+import { registerInvoiceRoutes } from '#/modules/invoice/infra/http/invoice.routes';
 import { InvoiceKafkaConsumer } from '#/modules/invoice/infra/messaging/kafka-consumer';
 import { KafkaProducer } from '#/modules/invoice/infra/messaging/kafka-producer';
 import {
@@ -169,6 +171,14 @@ export async function createContainer(config: AppConfig) {
     get: getCertificateCommand,
     list: listCertificatesCommand,
     delete: deleteCertificateCommand,
+  });
+
+  const getInvoiceQuery = new GetInvoiceQuery(invoiceRepository);
+  const listInvoicesQuery = new ListInvoicesQuery(invoiceRepository);
+
+  registerInvoiceRoutes(httpServer, {
+    get: getInvoiceQuery,
+    list: listInvoicesQuery,
   });
 
   await invoiceProducer.connect();

--- a/src/modules/invoice/app/queries/invoice.queries.ts
+++ b/src/modules/invoice/app/queries/invoice.queries.ts
@@ -1,0 +1,18 @@
+import { Invoice } from '../../domain/invoice';
+import { InvoiceRepository } from '../../domain/repository';
+
+export class GetInvoiceQuery {
+  constructor(private readonly invoiceRepository: InvoiceRepository) {}
+
+  async execute(id: string): Promise<Invoice | null> {
+    return this.invoiceRepository.getInvoiceById(id);
+  }
+}
+
+export class ListInvoicesQuery {
+  constructor(private readonly invoiceRepository: InvoiceRepository) {}
+
+  async execute(): Promise<Invoice[]> {
+    return this.invoiceRepository.findAll();
+  }
+}

--- a/src/modules/invoice/domain/repository.ts
+++ b/src/modules/invoice/domain/repository.ts
@@ -4,4 +4,5 @@ export interface InvoiceRepository {
   createInvoice(invoice: Invoice): Promise<Invoice>;
   updateInvoice(invoice: Invoice): Promise<Invoice>;
   getInvoiceById(id: string): Promise<Invoice | null>;
+  findAll(): Promise<Invoice[]>;
 }

--- a/src/modules/invoice/infra/http/invoice.routes.ts
+++ b/src/modules/invoice/infra/http/invoice.routes.ts
@@ -1,0 +1,110 @@
+import { FastifyInstance } from 'fastify';
+
+import { GetInvoiceQuery, ListInvoicesQuery } from '../../app/queries/invoice.queries';
+import { Invoice } from '../../domain/invoice';
+
+export interface InvoiceQueries {
+  get: GetInvoiceQuery;
+  list: ListInvoicesQuery;
+}
+
+const statusHistorySchema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    statusDate: { type: 'string', format: 'date-time' },
+    description: { type: 'string' },
+  },
+} as const;
+
+const invoiceSummaryProperties = {
+  id: { type: 'string', format: 'uuid' },
+  orderId: { type: 'string' },
+  accessCode: { type: 'string' },
+  status: { type: 'string' },
+  signatureId: { type: 'string' },
+  statusHistory: { type: 'array', items: statusHistorySchema },
+} as const;
+
+const invoiceDetailProperties = {
+  ...invoiceSummaryProperties,
+  xml: { type: 'string' },
+} as const;
+
+function toSummaryResponse(invoice: Invoice) {
+  return {
+    id: invoice.id,
+    orderId: invoice.orderId,
+    accessCode: invoice.accessCode.value,
+    status: invoice.status,
+    signatureId: invoice.signatureId,
+    statusHistory: invoice.statusHistory.map((h) => ({
+      name: h.name,
+      statusDate: h.statusDate.toISOString(),
+      description: h.description ?? '',
+    })),
+  };
+}
+
+function toDetailResponse(invoice: Invoice) {
+  return {
+    ...toSummaryResponse(invoice),
+    xml: invoice.xml,
+  };
+}
+
+export function registerInvoiceRoutes(app: FastifyInstance, queries: InvoiceQueries): void {
+  // GET /api/invoices — list all
+  app.get(
+    '/api/invoices',
+    {
+      schema: {
+        tags: ['Invoices'],
+        summary: 'List all invoices',
+        response: {
+          200: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: invoiceSummaryProperties,
+            },
+          },
+        },
+      },
+    },
+    async () => {
+      const invoices = await queries.list.execute();
+      return invoices.map(toSummaryResponse);
+    },
+  );
+
+  // GET /api/invoices/:id — get by ID
+  app.get<{ Params: { id: string } }>(
+    '/api/invoices/:id',
+    {
+      schema: {
+        tags: ['Invoices'],
+        summary: 'Get an invoice by ID',
+        params: {
+          type: 'object',
+          properties: { id: { type: 'string', format: 'uuid' } },
+          required: ['id'],
+        },
+        response: {
+          200: {
+            type: 'object',
+            properties: invoiceDetailProperties,
+          },
+          404: { type: 'object', properties: { error: { type: 'string' } } },
+        },
+      },
+    },
+    async (request, reply) => {
+      const invoice = await queries.get.execute(request.params.id);
+      if (!invoice) {
+        return reply.status(404).send({ error: 'Invoice not found' });
+      }
+      return toDetailResponse(invoice);
+    },
+  );
+}

--- a/src/modules/invoice/infra/persistence/dynamo-invoice.repository.ts
+++ b/src/modules/invoice/infra/persistence/dynamo-invoice.repository.ts
@@ -1,4 +1,4 @@
-import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, PutCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
 
 import { Invoice } from '../../domain/invoice';
 import { InvoiceRepository } from '../../domain/repository';
@@ -38,5 +38,10 @@ export class DynamoInvoiceRepository implements InvoiceRepository {
       }),
     );
     return result.Item ? fromInvoiceRecord(result.Item as InvoiceRecord) : null;
+  }
+
+  async findAll(): Promise<Invoice[]> {
+    const result = await this.docClient.send(new ScanCommand({ TableName: this.tableName }));
+    return (result.Items ?? []).map((item) => fromInvoiceRecord(item as InvoiceRecord));
   }
 }

--- a/src/shared/infra/http-server.ts
+++ b/src/shared/infra/http-server.ts
@@ -61,5 +61,5 @@ export async function createHttpServer(config: HttpServerConfig): Promise<Fastif
     async () => ({ status: 'ok' }),
   );
 
-  return app;
+  return app as unknown as FastifyInstance;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "dist",
     "strict": true,
     "esModuleInterop": true,
+    "skipLibCheck": true,
     "paths": {
       "#/*": ["./src/*"]
     }


### PR DESCRIPTION
  Add GET /api/invoices and GET /api/invoices/:id endpoints following
  the existing certificate CRUD pattern. List response excludes XML
  for efficiency; detail response includes full XML and status history.