### PR TITLE
feat: add company fiscal configuration module with GET/PUT endpoints

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -30,6 +30,7 @@ export interface AppConfig {
       tables: {
         invoices: string;
         certificates: string;
+        companyConfig: string;
       };
     };
     s3: {

--- a/src/config/local.ts
+++ b/src/config/local.ts
@@ -31,6 +31,7 @@ export default {
       tables: {
         invoices: 'invoices',
         certificates: 'certificates',
+        companyConfig: 'company_config',
       },
     },
     s3: {

--- a/src/config/production.ts
+++ b/src/config/production.ts
@@ -30,6 +30,7 @@ export default {
       tables: {
         invoices: 'invoices',
         certificates: 'certificates',
+        companyConfig: 'company_config',
       },
     },
     s3: {

--- a/src/container.ts
+++ b/src/container.ts
@@ -14,6 +14,12 @@ import { P12ParserAdapter } from '#/modules/certificate/infra/adapters/p12-parse
 import { S3StorageAdapter } from '#/modules/certificate/infra/adapters/s3-storage.adapter';
 import { registerCertificateRoutes } from '#/modules/certificate/infra/http/certificate.routes';
 import { DynamoCertificateRepository } from '#/modules/certificate/infra/persistence/dynamo-certificate.repository';
+import {
+  GetCompanyConfigQuery,
+  SaveCompanyConfigCommand,
+} from '#/modules/company-config/app/company-config.commands';
+import { registerCompanyConfigRoutes } from '#/modules/company-config/infra/http/company-config.routes';
+import { DynamoCompanyConfigRepository } from '#/modules/company-config/infra/persistence/dynamo-company-config.repository';
 import { AuthorizeInvoiceCommand } from '#/modules/invoice/app/commands/authorize-invoice';
 import { InvoiceCommand } from '#/modules/invoice/app/commands/command';
 import { CreateInvoiceCommand } from '#/modules/invoice/app/commands/create-invoice';
@@ -87,6 +93,10 @@ export async function createContainer(config: AppConfig) {
   const certificateRepository = new DynamoCertificateRepository(
     docClient,
     config.aws.dynamoDb.tables.certificates,
+  );
+  const companyConfigRepository = new DynamoCompanyConfigRepository(
+    docClient,
+    config.aws.dynamoDb.tables.companyConfig,
   );
 
   // Adapters
@@ -171,6 +181,15 @@ export async function createContainer(config: AppConfig) {
     get: getCertificateCommand,
     list: listCertificatesCommand,
     delete: deleteCertificateCommand,
+  });
+
+  // Company config module
+  const saveCompanyConfigCommand = new SaveCompanyConfigCommand(companyConfigRepository);
+  const getCompanyConfigQuery = new GetCompanyConfigQuery(companyConfigRepository);
+
+  registerCompanyConfigRoutes(httpServer, {
+    save: saveCompanyConfigCommand,
+    get: getCompanyConfigQuery,
   });
 
   const getInvoiceQuery = new GetInvoiceQuery(invoiceRepository);

--- a/src/modules/company-config/app/company-config.commands.ts
+++ b/src/modules/company-config/app/company-config.commands.ts
@@ -1,0 +1,34 @@
+import { CompanyConfig, EmissionType, Environment } from '../domain/company-config';
+import { CompanyConfigRepository } from '../domain/repository';
+
+export interface SaveCompanyConfigInput {
+  taxId: string;
+  name: string;
+  tradeName: string;
+  mainAddress: string;
+  branchAddress: string;
+  branchCode: string;
+  salePointCode: string;
+  specialTaxpayerResolution?: string | null;
+  withholdingAgentResolution?: string | null;
+  accountingRequired?: boolean;
+  environment: Environment;
+  emissionType: EmissionType;
+}
+
+export class SaveCompanyConfigCommand {
+  constructor(private readonly repository: CompanyConfigRepository) {}
+
+  async execute(input: SaveCompanyConfigInput): Promise<CompanyConfig> {
+    const config = CompanyConfig.create(input);
+    return this.repository.save(config);
+  }
+}
+
+export class GetCompanyConfigQuery {
+  constructor(private readonly repository: CompanyConfigRepository) {}
+
+  async execute(): Promise<CompanyConfig | null> {
+    return this.repository.find();
+  }
+}

--- a/src/modules/company-config/domain/company-config.ts
+++ b/src/modules/company-config/domain/company-config.ts
@@ -1,0 +1,61 @@
+export enum Environment {
+  TESTING = 1,
+  PRODUCTION = 2,
+}
+
+export enum EmissionType {
+  NORMAL = 1,
+}
+
+export class CompanyConfig {
+  static readonly SINGLETON_ID = 'default';
+
+  constructor(
+    public readonly id: string,
+    public readonly taxId: string,
+    public readonly name: string,
+    public readonly tradeName: string,
+    public readonly mainAddress: string,
+    public readonly branchAddress: string,
+    public readonly branchCode: string,
+    public readonly salePointCode: string,
+    public readonly specialTaxpayerResolution: string | null,
+    public readonly withholdingAgentResolution: string | null,
+    public readonly accountingRequired: boolean,
+    public readonly environment: Environment,
+    public readonly emissionType: EmissionType,
+    public readonly updatedAt: Date,
+  ) {}
+
+  static create(props: {
+    taxId: string;
+    name: string;
+    tradeName: string;
+    mainAddress: string;
+    branchAddress: string;
+    branchCode: string;
+    salePointCode: string;
+    specialTaxpayerResolution?: string | null;
+    withholdingAgentResolution?: string | null;
+    accountingRequired?: boolean;
+    environment: Environment;
+    emissionType: EmissionType;
+  }): CompanyConfig {
+    return new CompanyConfig(
+      CompanyConfig.SINGLETON_ID,
+      props.taxId,
+      props.name,
+      props.tradeName,
+      props.mainAddress,
+      props.branchAddress,
+      props.branchCode,
+      props.salePointCode,
+      props.specialTaxpayerResolution ?? null,
+      props.withholdingAgentResolution ?? null,
+      props.accountingRequired ?? false,
+      props.environment,
+      props.emissionType,
+      new Date(),
+    );
+  }
+}

--- a/src/modules/company-config/domain/repository.ts
+++ b/src/modules/company-config/domain/repository.ts
@@ -1,0 +1,6 @@
+import { CompanyConfig } from './company-config';
+
+export interface CompanyConfigRepository {
+  save(config: CompanyConfig): Promise<CompanyConfig>;
+  find(): Promise<CompanyConfig | null>;
+}

--- a/src/modules/company-config/infra/http/company-config.routes.ts
+++ b/src/modules/company-config/infra/http/company-config.routes.ts
@@ -1,0 +1,136 @@
+import { FastifyInstance } from 'fastify';
+
+import { logger } from '#/shared/logger';
+
+import {
+  GetCompanyConfigQuery,
+  SaveCompanyConfigCommand,
+  SaveCompanyConfigInput,
+} from '../../app/company-config.commands';
+import { CompanyConfig } from '../../domain/company-config';
+
+export interface CompanyConfigHandlers {
+  save: SaveCompanyConfigCommand;
+  get: GetCompanyConfigQuery;
+}
+
+const companyConfigResponseProperties = {
+  taxId: { type: 'string' },
+  name: { type: 'string' },
+  tradeName: { type: 'string' },
+  mainAddress: { type: 'string' },
+  branchAddress: { type: 'string' },
+  branchCode: { type: 'string' },
+  salePointCode: { type: 'string' },
+  specialTaxpayerResolution: { type: ['string', 'null'] },
+  withholdingAgentResolution: { type: ['string', 'null'] },
+  accountingRequired: { type: 'boolean' },
+  environment: { type: 'number' },
+  emissionType: { type: 'number' },
+  updatedAt: { type: 'string', format: 'date-time' },
+} as const;
+
+function toResponse(config: CompanyConfig) {
+  return {
+    taxId: config.taxId,
+    name: config.name,
+    tradeName: config.tradeName,
+    mainAddress: config.mainAddress,
+    branchAddress: config.branchAddress,
+    branchCode: config.branchCode,
+    salePointCode: config.salePointCode,
+    specialTaxpayerResolution: config.specialTaxpayerResolution,
+    withholdingAgentResolution: config.withholdingAgentResolution,
+    accountingRequired: config.accountingRequired,
+    environment: config.environment,
+    emissionType: config.emissionType,
+    updatedAt: config.updatedAt.toISOString(),
+  };
+}
+
+export function registerCompanyConfigRoutes(
+  app: FastifyInstance,
+  handlers: CompanyConfigHandlers,
+): void {
+  // PUT /api/company-config — create or update
+  app.put(
+    '/api/company-config',
+    {
+      schema: {
+        tags: ['Company Config'],
+        summary: 'Create or update the company fiscal configuration',
+        body: {
+          type: 'object',
+          required: [
+            'taxId',
+            'name',
+            'tradeName',
+            'mainAddress',
+            'branchAddress',
+            'branchCode',
+            'salePointCode',
+            'environment',
+            'emissionType',
+          ],
+          properties: {
+            taxId: { type: 'string', minLength: 13, maxLength: 13 },
+            name: { type: 'string', maxLength: 64 },
+            tradeName: { type: 'string', maxLength: 64 },
+            mainAddress: { type: 'string' },
+            branchAddress: { type: 'string' },
+            branchCode: { type: 'string', maxLength: 4 },
+            salePointCode: { type: 'string', maxLength: 4 },
+            specialTaxpayerResolution: { type: 'string', maxLength: 32 },
+            withholdingAgentResolution: { type: 'string', maxLength: 32 },
+            accountingRequired: { type: 'boolean' },
+            environment: { type: 'number', enum: [1, 2] },
+            emissionType: { type: 'number', enum: [1] },
+          },
+        },
+        response: {
+          200: {
+            type: 'object',
+            properties: companyConfigResponseProperties,
+          },
+          400: { type: 'object', properties: { error: { type: 'string' } } },
+        },
+      },
+    },
+    async (request, reply) => {
+      try {
+        const config = await handlers.save.execute(request.body as SaveCompanyConfigInput);
+        logger.info('Company config saved');
+        return reply.status(200).send(toResponse(config));
+      } catch (error) {
+        logger.error({ error }, 'Failed to save company config');
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return reply.status(400).send({ error: message });
+      }
+    },
+  );
+
+  // GET /api/company-config — get current config
+  app.get(
+    '/api/company-config',
+    {
+      schema: {
+        tags: ['Company Config'],
+        summary: 'Get the company fiscal configuration',
+        response: {
+          200: {
+            type: 'object',
+            properties: companyConfigResponseProperties,
+          },
+          404: { type: 'object', properties: { error: { type: 'string' } } },
+        },
+      },
+    },
+    async (_request, reply) => {
+      const config = await handlers.get.execute();
+      if (!config) {
+        return reply.status(404).send({ error: 'Company config not found' });
+      }
+      return toResponse(config);
+    },
+  );
+}

--- a/src/modules/company-config/infra/persistence/company-config.mapper.ts
+++ b/src/modules/company-config/infra/persistence/company-config.mapper.ts
@@ -1,0 +1,56 @@
+import { CompanyConfig, EmissionType, Environment } from '../../domain/company-config';
+
+export interface CompanyConfigRecord {
+  id: string;
+  tax_id: string;
+  name: string;
+  trade_name: string;
+  main_address: string;
+  branch_address: string;
+  branch_code: string;
+  sale_point_code: string;
+  special_taxpayer_resolution: string | null;
+  withholding_agent_resolution: string | null;
+  accounting_required: boolean;
+  environment: number;
+  emission_type: number;
+  updated_at: string;
+}
+
+export function toCompanyConfigRecord(config: CompanyConfig): CompanyConfigRecord {
+  return {
+    id: config.id,
+    tax_id: config.taxId,
+    name: config.name,
+    trade_name: config.tradeName,
+    main_address: config.mainAddress,
+    branch_address: config.branchAddress,
+    branch_code: config.branchCode,
+    sale_point_code: config.salePointCode,
+    special_taxpayer_resolution: config.specialTaxpayerResolution,
+    withholding_agent_resolution: config.withholdingAgentResolution,
+    accounting_required: config.accountingRequired,
+    environment: config.environment,
+    emission_type: config.emissionType,
+    updated_at: config.updatedAt.toISOString(),
+  };
+}
+
+export function fromCompanyConfigRecord(record: CompanyConfigRecord): CompanyConfig {
+  return new CompanyConfig(
+    record.id,
+    record.tax_id,
+    record.name,
+    record.trade_name,
+    record.main_address,
+    record.branch_address,
+    record.branch_code,
+    record.sale_point_code,
+    record.special_taxpayer_resolution,
+    record.withholding_agent_resolution,
+    record.accounting_required,
+    record.environment as Environment,
+    record.emission_type as EmissionType,
+    new Date(record.updated_at),
+  );
+}

--- a/src/modules/company-config/infra/persistence/dynamo-company-config.repository.ts
+++ b/src/modules/company-config/infra/persistence/dynamo-company-config.repository.ts
@@ -1,0 +1,36 @@
+import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+
+import { CompanyConfig } from '../../domain/company-config';
+import { CompanyConfigRepository } from '../../domain/repository';
+import {
+  CompanyConfigRecord,
+  fromCompanyConfigRecord,
+  toCompanyConfigRecord,
+} from './company-config.mapper';
+
+export class DynamoCompanyConfigRepository implements CompanyConfigRepository {
+  constructor(
+    private docClient: DynamoDBDocumentClient,
+    private tableName: string,
+  ) {}
+
+  async save(config: CompanyConfig): Promise<CompanyConfig> {
+    await this.docClient.send(
+      new PutCommand({
+        TableName: this.tableName,
+        Item: toCompanyConfigRecord(config),
+      }),
+    );
+    return config;
+  }
+
+  async find(): Promise<CompanyConfig | null> {
+    const result = await this.docClient.send(
+      new GetCommand({
+        TableName: this.tableName,
+        Key: { id: CompanyConfig.SINGLETON_ID },
+      }),
+    );
+    return result.Item ? fromCompanyConfigRecord(result.Item as CompanyConfigRecord) : null;
+  }
+}


### PR DESCRIPTION
  Add singleton company-config module to store SRI fiscal settings
  (tax ID, addresses, branch/sale-point codes, environment, emission type).
  Includes DynamoDB persistence and upsert/read HTTP endpoints.