### PR TITLE
feat: add Kafka consumer for sales.confirmed topic

### DIFF
--- a/src/config/local.ts
+++ b/src/config/local.ts
@@ -7,7 +7,7 @@ export default {
     level: 'debug',
   },
   http: {
-    port: 3000,
+    port: 3173,
     host: '0.0.0.0',
   },
   externalServices: {

--- a/src/config/production.ts
+++ b/src/config/production.ts
@@ -7,7 +7,7 @@ export default {
     level: 'info',
   },
   http: {
-    port: Number(process.env.HTTP_PORT) || 3000,
+    port: Number(process.env.HTTP_PORT) || 3173,
     host: '0.0.0.0',
   },
   externalServices: {

--- a/src/container.ts
+++ b/src/container.ts
@@ -27,6 +27,7 @@ import { SendInvoiceCommand } from '#/modules/invoice/app/commands/send-invoice'
 import { SignInvoiceCommand } from '#/modules/invoice/app/commands/sign-invoice';
 import { InvoiceMessageHandler } from '#/modules/invoice/app/handlers/invoice-message.handler';
 import { OrderMessageHandler } from '#/modules/invoice/app/handlers/order-message.handler';
+import { SaleConfirmedMessageHandler } from '#/modules/invoice/app/handlers/sale-confirmed-message.handler';
 import { GetInvoiceQuery, ListInvoicesQuery } from '#/modules/invoice/app/queries/invoice.queries';
 import { InvoiceStatus } from '#/modules/invoice/domain/invoice';
 import { CoreAdapter } from '#/modules/invoice/infra/adapters/core.adapter';
@@ -40,6 +41,7 @@ import {
   InvoiceMessageSchema,
   OrderMessageSchema,
   OrderResponseSchema,
+  SaleConfirmedMessageSchema,
 } from '#/modules/invoice/infra/messaging/schemas';
 import { KAFKA_TOPICS } from '#/modules/invoice/infra/messaging/topics';
 import { DynamoInvoiceRepository } from '#/modules/invoice/infra/persistence/dynamo-invoice.repository';
@@ -139,11 +141,12 @@ export async function createContainer(config: AppConfig) {
     commandMap,
     invoiceProducer,
   );
+  const saleConfirmedHandler = new SaleConfirmedMessageHandler();
 
   // Consumer
   const kafkaConsumer = new InvoiceKafkaConsumer(
     consumer,
-    [KAFKA_TOPICS.ORDERS, KAFKA_TOPICS.INVOICES],
+    [KAFKA_TOPICS.ORDERS, KAFKA_TOPICS.INVOICES, KAFKA_TOPICS.SALES_CONFIRMED],
     {
       [KAFKA_TOPICS.ORDERS]: {
         handler: orderMessageHandler,
@@ -152,6 +155,10 @@ export async function createContainer(config: AppConfig) {
       [KAFKA_TOPICS.INVOICES]: {
         handler: invoiceMessageHandler,
         validator: InvoiceMessageSchema,
+      },
+      [KAFKA_TOPICS.SALES_CONFIRMED]: {
+        handler: saleConfirmedHandler,
+        validator: SaleConfirmedMessageSchema,
       },
     },
   );

--- a/src/modules/invoice/app/handlers/sale-confirmed-message.handler.ts
+++ b/src/modules/invoice/app/handlers/sale-confirmed-message.handler.ts
@@ -1,0 +1,7 @@
+import { logger } from '#/shared/logger';
+
+export class SaleConfirmedMessageHandler {
+  async handle(message: unknown): Promise<void> {
+    logger.info({ event: message }, 'Sale confirmed event received');
+  }
+}

--- a/src/modules/invoice/infra/messaging/schemas.ts
+++ b/src/modules/invoice/infra/messaging/schemas.ts
@@ -112,3 +112,7 @@ export const InvoiceMessageSchema = z.object({
 });
 
 export type InvoiceMessage = z.infer<typeof InvoiceMessageSchema>;
+
+export const SaleConfirmedMessageSchema = z.record(z.unknown());
+
+export type SaleConfirmedMessage = z.infer<typeof SaleConfirmedMessageSchema>;

--- a/src/modules/invoice/infra/messaging/topics.ts
+++ b/src/modules/invoice/infra/messaging/topics.ts
@@ -1,4 +1,5 @@
 export enum KAFKA_TOPICS {
   ORDERS = 'orders',
   INVOICES = 'invoices',
+  SALES_CONFIRMED = 'sales.confirmed',
 }


### PR DESCRIPTION
  Subscribe to the sales.confirmed topic to start migrating order
  processing away from the external core service. The handler only
  logs the event for now; actual processing will be added incrementally.
  Also updates the default HTTP port to 3173.