### PR TITLE
feat: add dynamic invoice sequence counter to company config

### DIFF
--- a/src/modules/company-config/app/company-config.commands.ts
+++ b/src/modules/company-config/app/company-config.commands.ts
@@ -14,13 +14,19 @@ export interface SaveCompanyConfigInput {
   accountingRequired?: boolean;
   environment: Environment;
   emissionType: EmissionType;
+  invoiceSequence?: number;
 }
 
 export class SaveCompanyConfigCommand {
   constructor(private readonly repository: CompanyConfigRepository) {}
 
   async execute(input: SaveCompanyConfigInput): Promise<CompanyConfig> {
-    const config = CompanyConfig.create(input);
+    let invoiceSequence = input.invoiceSequence;
+    if (invoiceSequence === undefined) {
+      const current = await this.repository.find();
+      invoiceSequence = current?.invoiceSequence ?? 1;
+    }
+    const config = CompanyConfig.create({ ...input, invoiceSequence });
     return this.repository.save(config);
   }
 }

--- a/src/modules/company-config/domain/company-config.ts
+++ b/src/modules/company-config/domain/company-config.ts
@@ -24,6 +24,7 @@ export class CompanyConfig {
     public readonly accountingRequired: boolean,
     public readonly environment: Environment,
     public readonly emissionType: EmissionType,
+    public readonly invoiceSequence: number,
     public readonly updatedAt: Date,
   ) {}
 
@@ -40,6 +41,7 @@ export class CompanyConfig {
     accountingRequired?: boolean;
     environment: Environment;
     emissionType: EmissionType;
+    invoiceSequence?: number;
   }): CompanyConfig {
     return new CompanyConfig(
       CompanyConfig.SINGLETON_ID,
@@ -55,6 +57,7 @@ export class CompanyConfig {
       props.accountingRequired ?? false,
       props.environment,
       props.emissionType,
+      props.invoiceSequence ?? 1,
       new Date(),
     );
   }

--- a/src/modules/company-config/domain/repository.ts
+++ b/src/modules/company-config/domain/repository.ts
@@ -3,4 +3,5 @@ import { CompanyConfig } from './company-config';
 export interface CompanyConfigRepository {
   save(config: CompanyConfig): Promise<CompanyConfig>;
   find(): Promise<CompanyConfig | null>;
+  nextInvoiceSequence(): Promise<number>;
 }

--- a/src/modules/company-config/infra/http/company-config.mapper.ts
+++ b/src/modules/company-config/infra/http/company-config.mapper.ts
@@ -14,6 +14,7 @@ export function toResponse(config: CompanyConfig) {
     accountingRequired: config.accountingRequired,
     environment: config.environment,
     emissionType: config.emissionType,
+    invoiceSequence: config.invoiceSequence,
     updatedAt: config.updatedAt.toISOString(),
   };
 }

--- a/src/modules/company-config/infra/http/company-config.schemas.ts
+++ b/src/modules/company-config/infra/http/company-config.schemas.ts
@@ -11,6 +11,7 @@ const companyConfigResponseProperties = {
   accountingRequired: { type: 'boolean' },
   environment: { type: 'number' },
   emissionType: { type: 'number' },
+  invoiceSequence: { type: 'number' },
   updatedAt: { type: 'string', format: 'date-time' },
 } as const;
 
@@ -48,6 +49,7 @@ export const saveCompanyConfigSchema = {
       accountingRequired: { type: 'boolean' },
       environment: { type: 'number', enum: [1, 2] },
       emissionType: { type: 'number', enum: [1] },
+      invoiceSequence: { type: 'number', minimum: 1 },
     },
   },
   response: {

--- a/src/modules/company-config/infra/persistence/company-config.mapper.ts
+++ b/src/modules/company-config/infra/persistence/company-config.mapper.ts
@@ -14,6 +14,7 @@ export interface CompanyConfigRecord {
   accounting_required: boolean;
   environment: number;
   emission_type: number;
+  invoice_sequence: number;
   updated_at: string;
 }
 
@@ -32,6 +33,7 @@ export function toCompanyConfigRecord(config: CompanyConfig): CompanyConfigRecor
     accounting_required: config.accountingRequired,
     environment: config.environment,
     emission_type: config.emissionType,
+    invoice_sequence: config.invoiceSequence,
     updated_at: config.updatedAt.toISOString(),
   };
 }
@@ -51,6 +53,7 @@ export function fromCompanyConfigRecord(record: CompanyConfigRecord): CompanyCon
     record.accounting_required,
     record.environment as Environment,
     record.emission_type as EmissionType,
+    record.invoice_sequence ?? 1,
     new Date(record.updated_at),
   );
 }

--- a/src/modules/company-config/infra/persistence/dynamo-company-config.repository.ts
+++ b/src/modules/company-config/infra/persistence/dynamo-company-config.repository.ts
@@ -1,4 +1,9 @@
-import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
 
 import { CompanyConfig } from '../../domain/company-config';
 import { CompanyConfigRepository } from '../../domain/repository';
@@ -32,5 +37,18 @@ export class DynamoCompanyConfigRepository implements CompanyConfigRepository {
       }),
     );
     return result.Item ? fromCompanyConfigRecord(result.Item as CompanyConfigRecord) : null;
+  }
+
+  async nextInvoiceSequence(): Promise<number> {
+    const result = await this.docClient.send(
+      new UpdateCommand({
+        TableName: this.tableName,
+        Key: { id: CompanyConfig.SINGLETON_ID },
+        UpdateExpression: 'ADD invoice_sequence :one',
+        ExpressionAttributeValues: { ':one': 1 },
+        ReturnValues: 'UPDATED_NEW',
+      }),
+    );
+    return result.Attributes!.invoice_sequence as number;
   }
 }

--- a/src/modules/invoice/app/commands/create-invoice-from-sale.ts
+++ b/src/modules/invoice/app/commands/create-invoice-from-sale.ts
@@ -8,7 +8,6 @@ import { InvoiceRepository } from '../../domain/repository';
 import { PAYMENT_METHOD_CODES, TAX_RATE_CODES, TAX_TYPE_CODES } from '../../domain/sri-catalogs';
 import { SaleConfirmedMessage } from '../../infra/messaging/schemas';
 
-const DEFAULT_SEQUENCE = '000000601';
 const VOUCHER_TYPE_CODE = '01';
 
 export class CreateInvoiceFromSaleCommand {
@@ -25,12 +24,10 @@ export class CreateInvoiceFromSaleCommand {
     const date = new Date(message.occurred_at);
     const { payload } = message;
 
-    const accessCodeStr = generateAccessCode(
-      date,
-      companyConfig,
-      payload.sale_id,
-      DEFAULT_SEQUENCE,
-    );
+    const sequenceNum = await this.companyConfigRepository.nextInvoiceSequence();
+    const sequence = String(sequenceNum).padStart(9, '0');
+
+    const accessCodeStr = generateAccessCode(date, companyConfig, payload.sale_id, sequence);
 
     const customer = payload.customer
       ? {
@@ -60,7 +57,7 @@ export class CreateInvoiceFromSaleCommand {
       companySalePointCode: companyConfig.salePointCode,
       companyAccountingRequired: companyConfig.accountingRequired,
       accessCode: accessCodeStr,
-      sequence: DEFAULT_SEQUENCE,
+      sequence,
       voucherTypeCode: VOUCHER_TYPE_CODE,
       date,
       customer,


### PR DESCRIPTION
  Extends CompanyConfig with an invoiceSequence counter that auto-increments
  atomically via DynamoDB UpdateCommand ADD on each invoice creation.
  The sequence is configurable via PUT /api/company-config and visible in GET.
  Removes the hardcoded DEFAULT_SEQUENCE from CreateInvoiceFromSaleCommand.