### PR TITLE
feat: move signing certificate ID from env var into company config

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ The service acts as both producer and consumer on the `invoices` topic to implem
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `SIGNING_P12_ID` | Yes | UUID of the signing certificate stored in DynamoDB |
 | `SIGNING_P12_PASSWORD` | Yes | Password for the `.p12` certificate |
 | `AWS_ACCESS_KEY_ID` | Yes | AWS credentials |
 | `AWS_SECRET_ACCESS_KEY` | Yes | AWS credentials |
@@ -202,7 +201,6 @@ Set via `CompanyConfig.environment`:
    AWS_SECRET_ACCESS_KEY=test
    AWS_ACCESS_KEY_ID=test
    AWS_REGION=us-east-1
-   SIGNING_P12_ID=<uuid-of-uploaded-certificate>
    SIGNING_P12_PASSWORD=<p12-password>
    ```
 
@@ -236,10 +234,10 @@ Before processing invoices, bootstrap the service via the REST API:
    curl -X POST http://localhost:3173/api/certificates \
      -F "file=@/path/to/certificate.p12" \
      -F "password=your-p12-password"
-   # Copy the returned `id` → use as SIGNING_P12_ID
+   # Copy the returned `id` → use as signingCertId in the next step
    ```
 
-2. **Save company fiscal config**
+2. **Save company fiscal config** (include the certificate `id` from step 1)
 
    ```bash
    curl -X PUT http://localhost:3173/api/company-config \
@@ -254,7 +252,8 @@ Before processing invoices, bootstrap the service via the REST API:
        "salePointCode": "001",
        "accountingRequired": false,
        "environment": 1,
-       "emissionType": 1
+       "emissionType": 1,
+       "signingCertId": "<uuid-from-step-1>"
      }'
    ```
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -13,7 +13,6 @@ export interface AppConfig {
     sriQueryWsdl: string;
   };
   signing: {
-    p12Id: string;
     p12Password: string;
   };
   kafka: {

--- a/src/config/local.ts
+++ b/src/config/local.ts
@@ -35,7 +35,6 @@ export default {
     },
   },
   signing: {
-    p12Id: process.env.SIGNING_P12_ID || '',
     p12Password: process.env.SIGNING_P12_PASSWORD || '',
   },
   timezone: 'America/Guayaquil',

--- a/src/config/production.ts
+++ b/src/config/production.ts
@@ -34,7 +34,6 @@ export default {
     },
   },
   signing: {
-    p12Id: process.env.SIGNING_P12_ID!,
     p12Password: process.env.SIGNING_P12_PASSWORD!,
   },
   timezone: 'America/Guayaquil',

--- a/src/container.ts
+++ b/src/container.ts
@@ -104,7 +104,7 @@ export async function createContainer(config: AppConfig) {
     certificateRepository,
     s3Storage,
     xadesSigner,
-    config.signing.p12Id,
+    companyConfigRepository,
     config.signing.p12Password,
   );
   const sriValidationAdapter = new SriValidationAdapter(validationClient);
@@ -128,11 +128,7 @@ export async function createContainer(config: AppConfig) {
     [InvoiceStatus.SENT, authorizeInvoiceCommand],
   ]);
 
-  const createInvoiceCommand = new CreateInvoiceCommand(
-    companyConfigRepository,
-    invoiceRepository,
-    config.signing.p12Id,
-  );
+  const createInvoiceCommand = new CreateInvoiceCommand(companyConfigRepository, invoiceRepository);
 
   // Handlers
   const invoiceEventHandler = new InvoiceEventHandler(

--- a/src/modules/certificate/infra/http/certificate.schemas.ts
+++ b/src/modules/certificate/infra/http/certificate.schemas.ts
@@ -2,7 +2,8 @@ const certificateResponseProperties = {
   id: {
     type: 'string',
     format: 'uuid',
-    description: 'Unique certificate identifier. Use this value as SIGNING_P12_ID.',
+    description:
+      'Unique certificate identifier. Set this value as the `signingCertId` in the company configuration (PUT /api/company-config).',
   },
   serialNumber: {
     type: 'string',
@@ -55,7 +56,7 @@ export const uploadCertificateSchema = {
   tags: ['Certificates'],
   summary: 'Upload a .p12 digital signature certificate',
   description:
-    'Accepts a PKCS#12 (.p12) file and its password. The service parses the certificate metadata, stores the file in S3, and persists the metadata in DynamoDB. The returned `id` should be set as the `SIGNING_P12_ID` environment variable so the service uses this certificate to sign invoices.',
+    'Accepts a PKCS#12 (.p12) file and its password. The service parses the certificate metadata, stores the file in S3, and persists the metadata in DynamoDB. The returned `id` should be saved as the `signingCertId` field in the company configuration (PUT /api/company-config) so the service uses this certificate to sign invoices.',
   multipartBody: {
     type: 'object',
     required: ['file', 'password'],
@@ -126,7 +127,7 @@ export const deleteCertificateSchema = {
   tags: ['Certificates'],
   summary: 'Delete a certificate',
   description:
-    'Deletes the certificate from both DynamoDB and S3. If the certificate is currently configured as SIGNING_P12_ID, invoice signing will fail until a new certificate is configured.',
+    'Deletes the certificate from both DynamoDB and S3. If this certificate is currently set as the `signingCertId` in company configuration, invoice signing will fail until a new certificate is configured.',
   params: {
     type: 'object',
     properties: { id: { type: 'string', format: 'uuid', description: 'Certificate UUID.' } },

--- a/src/modules/company-config/app/company-config.commands.ts
+++ b/src/modules/company-config/app/company-config.commands.ts
@@ -15,6 +15,7 @@ export interface SaveCompanyConfigInput {
   environment: Environment;
   emissionType: EmissionType;
   invoiceSequence?: number;
+  signingCertId?: string | null;
 }
 
 export class SaveCompanyConfigCommand {

--- a/src/modules/company-config/domain/company-config.ts
+++ b/src/modules/company-config/domain/company-config.ts
@@ -25,6 +25,7 @@ export class CompanyConfig {
     public readonly environment: Environment,
     public readonly emissionType: EmissionType,
     public readonly invoiceSequence: number,
+    public readonly signingCertId: string | null,
     public readonly updatedAt: Date,
   ) {}
 
@@ -42,6 +43,7 @@ export class CompanyConfig {
     environment: Environment;
     emissionType: EmissionType;
     invoiceSequence?: number;
+    signingCertId?: string | null;
   }): CompanyConfig {
     return new CompanyConfig(
       CompanyConfig.SINGLETON_ID,
@@ -58,6 +60,7 @@ export class CompanyConfig {
       props.environment,
       props.emissionType,
       props.invoiceSequence ?? 1,
+      props.signingCertId ?? null,
       new Date(),
     );
   }

--- a/src/modules/company-config/infra/http/company-config.mapper.ts
+++ b/src/modules/company-config/infra/http/company-config.mapper.ts
@@ -15,6 +15,7 @@ export function toResponse(config: CompanyConfig) {
     environment: config.environment,
     emissionType: config.emissionType,
     invoiceSequence: config.invoiceSequence,
+    signingCertId: config.signingCertId,
     updatedAt: config.updatedAt.toISOString(),
   };
 }

--- a/src/modules/company-config/infra/http/company-config.schemas.ts
+++ b/src/modules/company-config/infra/http/company-config.schemas.ts
@@ -60,6 +60,12 @@ const companyConfigResponseProperties = {
       'Current sequential invoice counter. Auto-incremented on each invoice creation. Can be seeded on first setup.',
     example: 42,
   },
+  signingCertId: {
+    type: ['string', 'null'],
+    format: 'uuid',
+    description:
+      'UUID of the PKCS#12 certificate used to sign invoices. Set this to the `id` returned by the certificate upload endpoint. Null if no certificate has been configured.',
+  },
   updatedAt: {
     type: 'string',
     format: 'date-time',
@@ -96,19 +102,16 @@ export const saveCompanyConfigSchema = {
         minLength: 13,
         maxLength: 13,
         description: 'Company RUC — exactly 13 digits.',
-        example: '1792141001001',
       },
       name: {
         type: 'string',
         maxLength: 64,
         description: 'Legal company name (max 64 chars).',
-        example: 'ACME SOLUTIONS S.A.',
       },
       tradeName: {
         type: 'string',
         maxLength: 64,
         description: 'Trade name (max 64 chars).',
-        example: 'ACME',
       },
       mainAddress: { type: 'string', description: 'Main establishment address.' },
       branchAddress: { type: 'string', description: 'Branch address printed on invoices.' },
@@ -116,13 +119,11 @@ export const saveCompanyConfigSchema = {
         type: 'string',
         maxLength: 4,
         description: 'Branch code (max 4 chars).',
-        example: '001',
       },
       salePointCode: {
         type: 'string',
         maxLength: 4,
         description: 'Point-of-sale code (max 4 chars).',
-        example: '001',
       },
       specialTaxpayerResolution: {
         type: 'string',
@@ -153,6 +154,12 @@ export const saveCompanyConfigSchema = {
         minimum: 1,
         description:
           'Seed value for the invoice sequence counter. Optional — preserves the existing counter if omitted.',
+      },
+      signingCertId: {
+        type: 'string',
+        format: 'uuid',
+        description:
+          'UUID of the signing certificate. Use the `id` returned by POST /api/certificates/upload.',
       },
     },
   },

--- a/src/modules/company-config/infra/persistence/company-config.mapper.ts
+++ b/src/modules/company-config/infra/persistence/company-config.mapper.ts
@@ -15,6 +15,7 @@ export interface CompanyConfigRecord {
   environment: number;
   emission_type: number;
   invoice_sequence: number;
+  signing_cert_id: string | null;
   updated_at: string;
 }
 
@@ -34,6 +35,7 @@ export function toCompanyConfigRecord(config: CompanyConfig): CompanyConfigRecor
     environment: config.environment,
     emission_type: config.emissionType,
     invoice_sequence: config.invoiceSequence,
+    signing_cert_id: config.signingCertId,
     updated_at: config.updatedAt.toISOString(),
   };
 }
@@ -54,6 +56,7 @@ export function fromCompanyConfigRecord(record: CompanyConfigRecord): CompanyCon
     record.environment as Environment,
     record.emission_type as EmissionType,
     record.invoice_sequence ?? 1,
+    record.signing_cert_id ?? null,
     new Date(record.updated_at),
   );
 }

--- a/src/modules/invoice/app/commands/create-invoice.ts
+++ b/src/modules/invoice/app/commands/create-invoice.ts
@@ -14,12 +14,13 @@ export class CreateInvoiceCommand {
   constructor(
     private companyConfigRepository: CompanyConfigRepository,
     private invoiceRepository: InvoiceRepository,
-    private signingCertId: string,
   ) {}
 
   async execute(message: SaleConfirmedMessage): Promise<Invoice> {
     const companyConfig = await this.companyConfigRepository.find();
     if (!companyConfig) throw new Error('Company config not found');
+    if (!companyConfig.signingCertId)
+      throw new Error('No signing certificate configured in company config');
 
     const date = new Date(message.occurred_at);
     const { payload } = message;
@@ -88,7 +89,7 @@ export class CreateInvoiceCommand {
     const invoice = Invoice.create(
       String(payload.sale_id),
       AccessCode.create(accessCodeStr),
-      this.signingCertId,
+      companyConfig.signingCertId,
       xml,
     );
     await this.invoiceRepository.createInvoice(invoice);

--- a/src/modules/invoice/infra/adapters/signer.adapter.ts
+++ b/src/modules/invoice/infra/adapters/signer.adapter.ts
@@ -1,5 +1,6 @@
 import { FileStoragePort } from '#/modules/certificate/domain/ports';
 import { CertificateRepository } from '#/modules/certificate/domain/repository';
+import { CompanyConfigRepository } from '#/modules/company-config/domain/repository';
 
 import { InvoiceSignerPort } from '../../domain/ports';
 import { P12Reader, SigningCredentials } from '../signing/p12-reader';
@@ -7,12 +8,13 @@ import { XadesSigner } from '../signing/xades-signer';
 
 export class SignerAdapter implements InvoiceSignerPort {
   private credentials: SigningCredentials | null = null;
+  private cachedP12Id: string | null = null;
 
   constructor(
     private readonly certificateRepository: CertificateRepository,
     private readonly fileStorage: FileStoragePort,
     private readonly xadesSigner: XadesSigner,
-    private readonly p12Id: string,
+    private readonly companyConfigRepository: CompanyConfigRepository,
     private readonly p12Password: string,
   ) {}
 
@@ -22,20 +24,21 @@ export class SignerAdapter implements InvoiceSignerPort {
   }
 
   private async getCredentials(): Promise<SigningCredentials> {
-    if (this.credentials) return this.credentials;
+    const companyConfig = await this.companyConfigRepository.find();
+    if (!companyConfig) throw new Error('Company config not found');
 
-    if (!this.p12Id) {
-      throw new Error('SIGNING_P12_ID environment variable is not configured');
-    }
+    const { signingCertId } = companyConfig;
+    if (!signingCertId) throw new Error('No signing certificate configured in company config');
 
-    const certificate = await this.certificateRepository.findById(this.p12Id);
-    if (!certificate) {
-      throw new Error(`Signing certificate not found: ${this.p12Id}`);
-    }
+    if (this.credentials && this.cachedP12Id === signingCertId) return this.credentials;
+
+    const certificate = await this.certificateRepository.findById(signingCertId);
+    if (!certificate) throw new Error(`Signing certificate not found: ${signingCertId}`);
 
     const p12Buffer = await this.fileStorage.download(certificate.s3Key);
     const p12Reader = new P12Reader(p12Buffer, this.p12Password);
     this.credentials = p12Reader.getCredentials();
+    this.cachedP12Id = signingCertId;
 
     return this.credentials;
   }


### PR DESCRIPTION
Add  field to  entity so operators can
configure the signing certificate via PUT /api/company-config instead of the  environment variable.

-  now reads  from at signing time; credential cache invalidates automatically on cert change
-  reads  from the already-loaded object instead of a constructor arg
- Remove  from  interface and config files
- Update API schemas, HTTP mappers, persistence mapper, and docs
- Fix AJV strict mode error caused by  keyword in body schema