### PR TITLE
feat: standardize HTTP response envelope across all endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Event-driven microservice that integrates with Ecuador's **SRI** (Servicio de Re
 - [Invoice Lifecycle](#invoice-lifecycle)
 - [Modules](#modules)
 - [HTTP API](#http-api)
+- [API Response Format](#api-response-format)
 - [Kafka Topics](#kafka-topics)
 - [Configuration](#configuration)
 - [Local Development](#local-development)
@@ -127,6 +128,61 @@ Interactive docs available at `http://localhost:3173/docs` (Scalar UI) when the 
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/health` | Service health check |
+
+---
+
+## API Response Format
+
+All endpoints return a consistent JSON envelope.
+
+### Success
+
+```json
+{
+  "data": { } ,
+  "meta": {
+    "requestId": "73e47c92-cfa9-49a6-86c5-c027a0adb6ae",
+    "timestamp": "2026-04-08T14:31:02.563Z"
+  }
+}
+```
+
+`data` can be an object (single resource) or an array (collection). `meta` is always present.
+
+### Error
+
+```json
+{
+  "errors": [
+    {
+      "code": "NOT_FOUND",
+      "message": "Invoice not found"
+    }
+  ],
+  "meta": {
+    "requestId": "73e47c92-cfa9-49a6-86c5-c027a0adb6ae",
+    "timestamp": "2026-04-08T14:31:02.563Z"
+  }
+}
+```
+
+#### Error codes
+
+| Code | HTTP status | When |
+|------|-------------|------|
+| `NOT_FOUND` | 404 | Resource does not exist |
+| `BAD_REQUEST` | 400 | Invalid input (missing file, wrong extension, etc.) |
+| `VALIDATION_ERROR` | 422 | Request body fails schema validation |
+| `INTERNAL_ERROR` | 500 | Unexpected server error |
+
+### Request ID propagation
+
+Every response includes a `requestId` in `meta`. If the request carries an `X-Request-ID` header, that value is used as-is (useful for distributed tracing). Otherwise a UUID v4 is generated automatically.
+
+```bash
+curl -H "X-Request-ID: my-trace-id" http://localhost:3173/api/invoices
+# → meta.requestId will be "my-trace-id"
+```
 
 ---
 

--- a/src/modules/certificate/app/certificate.commands.ts
+++ b/src/modules/certificate/app/certificate.commands.ts
@@ -1,3 +1,5 @@
+import { NotFoundError } from '#/shared/errors/app-error';
+
 import { Certificate } from '../domain/certificate';
 import { FileStoragePort, P12ParserPort } from '../domain/ports';
 import { CertificateRepository } from '../domain/repository';
@@ -61,7 +63,7 @@ export class DeleteCertificateCommand {
   async execute(id: string): Promise<void> {
     const certificate = await this.certificateRepository.findById(id);
     if (!certificate) {
-      throw new Error(`Certificate with id ${id} not found`);
+      throw new NotFoundError(`Certificate with id ${id} not found`);
     }
 
     await this.fileStorage.delete(certificate.s3Key);

--- a/src/modules/certificate/infra/http/certificate.routes.ts
+++ b/src/modules/certificate/infra/http/certificate.routes.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from 'fastify';
 
+import { BadRequestError, NotFoundError, ValidationError } from '#/shared/errors/app-error';
 import { logger } from '#/shared/logger';
 
 import {
@@ -31,11 +32,11 @@ export function registerCertificateRoutes(
   app.post('/api/certificates', { schema: uploadCertificateSchema }, async (request, reply) => {
     const data = await request.file();
     if (!data) {
-      return reply.status(400).send({ error: 'No file uploaded' });
+      throw new BadRequestError('No file uploaded');
     }
 
     if (!data.filename.endsWith('.p12')) {
-      return reply.status(400).send({ error: 'Only .p12 files are accepted' });
+      throw new BadRequestError('Only .p12 files are accepted');
     }
 
     const chunks: Buffer[] = [];
@@ -56,18 +57,19 @@ export function registerCertificateRoutes(
       });
 
       logger.info({ certificateId: certificate.id }, 'Certificate uploaded');
-      return reply.status(201).send(toResponse(certificate));
+      reply.code(201);
+      return reply.success(toResponse(certificate));
     } catch (error) {
       logger.error({ error }, 'Failed to upload certificate');
       const message = error instanceof Error ? error.message : 'Unknown error';
-      return reply.status(422).send({ error: message });
+      throw new ValidationError(message);
     }
   });
 
   // GET /api/certificates — list all
-  app.get('/api/certificates', { schema: listCertificatesSchema }, async () => {
+  app.get('/api/certificates', { schema: listCertificatesSchema }, async (_request, reply) => {
     const certificates = await commands.list.execute();
-    return certificates.map(toResponse);
+    return reply.success(certificates.map(toResponse));
   });
 
   // GET /api/certificates/:id — get by ID
@@ -77,9 +79,9 @@ export function registerCertificateRoutes(
     async (request, reply) => {
       const certificate = await commands.get.execute(request.params.id);
       if (!certificate) {
-        return reply.status(404).send({ error: 'Certificate not found' });
+        throw new NotFoundError('Certificate not found');
       }
-      return toResponse(certificate);
+      return reply.success(toResponse(certificate));
     },
   );
 
@@ -88,14 +90,8 @@ export function registerCertificateRoutes(
     '/api/certificates/:id',
     { schema: deleteCertificateSchema },
     async (request, reply) => {
-      try {
-        await commands.delete.execute(request.params.id);
-        return reply.status(204).send();
-      } catch (error) {
-        logger.error({ error }, 'Failed to delete certificate');
-        const message = error instanceof Error ? error.message : 'Unknown error';
-        return reply.status(404).send({ error: message });
-      }
+      await commands.delete.execute(request.params.id);
+      return reply.code(204).send();
     },
   );
 }

--- a/src/modules/certificate/infra/http/certificate.schemas.ts
+++ b/src/modules/certificate/infra/http/certificate.schemas.ts
@@ -1,3 +1,5 @@
+import { errorResponseSchema, successSchema } from '#/shared/infra/http/shared-schemas';
+
 const certificateResponseProperties = {
   id: {
     type: 'string',
@@ -47,9 +49,9 @@ const certificateResponseProperties = {
   },
 } as const;
 
-const errorResponse = {
+const certificateObjectSchema = {
   type: 'object',
-  properties: { error: { type: 'string' } },
+  properties: certificateResponseProperties,
 } as const;
 
 export const uploadCertificateSchema = {
@@ -75,16 +77,15 @@ export const uploadCertificateSchema = {
   },
   response: {
     201: {
-      type: 'object',
+      ...successSchema(certificateObjectSchema),
       description: 'Certificate uploaded and parsed successfully.',
-      properties: certificateResponseProperties,
     },
     400: {
-      ...errorResponse,
+      ...errorResponseSchema,
       description: 'Missing file, wrong file extension, or invalid request.',
     },
     422: {
-      ...errorResponse,
+      ...errorResponseSchema,
       description: 'File could not be parsed — wrong password or corrupted .p12.',
     },
   },
@@ -95,13 +96,7 @@ export const listCertificatesSchema = {
   summary: 'List all certificates',
   description: 'Returns all certificates stored in the system.',
   response: {
-    200: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: certificateResponseProperties,
-      },
-    },
+    200: successSchema({ type: 'array', items: certificateObjectSchema }),
   },
 } as const;
 
@@ -115,11 +110,8 @@ export const getCertificateSchema = {
     required: ['id'],
   },
   response: {
-    200: {
-      type: 'object',
-      properties: certificateResponseProperties,
-    },
-    404: { ...errorResponse, description: 'No certificate found with the given ID.' },
+    200: successSchema(certificateObjectSchema),
+    404: { ...errorResponseSchema, description: 'No certificate found with the given ID.' },
   },
 } as const;
 
@@ -135,6 +127,6 @@ export const deleteCertificateSchema = {
   },
   response: {
     204: { type: 'null', description: 'Certificate deleted successfully.' },
-    404: { ...errorResponse, description: 'No certificate found with the given ID.' },
+    404: { ...errorResponseSchema, description: 'No certificate found with the given ID.' },
   },
 } as const;

--- a/src/modules/company-config/infra/http/company-config.routes.ts
+++ b/src/modules/company-config/infra/http/company-config.routes.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from 'fastify';
 
+import { BadRequestError, NotFoundError } from '#/shared/errors/app-error';
 import { logger } from '#/shared/logger';
 
 import {
@@ -24,11 +25,11 @@ export function registerCompanyConfigRoutes(
     try {
       const config = await handlers.save.execute(request.body as SaveCompanyConfigInput);
       logger.info('Company config saved');
-      return reply.status(200).send(toResponse(config));
+      return reply.success(toResponse(config));
     } catch (error) {
       logger.error({ error }, 'Failed to save company config');
       const message = error instanceof Error ? error.message : 'Unknown error';
-      return reply.status(400).send({ error: message });
+      throw new BadRequestError(message);
     }
   });
 
@@ -36,8 +37,8 @@ export function registerCompanyConfigRoutes(
   app.get('/api/company-config', { schema: getCompanyConfigSchema }, async (_request, reply) => {
     const config = await handlers.get.execute();
     if (!config) {
-      return reply.status(404).send({ error: 'Company config not found' });
+      throw new NotFoundError('Company config not found');
     }
-    return toResponse(config);
+    return reply.success(toResponse(config));
   });
 }

--- a/src/modules/company-config/infra/http/company-config.schemas.ts
+++ b/src/modules/company-config/infra/http/company-config.schemas.ts
@@ -1,3 +1,5 @@
+import { errorResponseSchema, successSchema } from '#/shared/infra/http/shared-schemas';
+
 const companyConfigResponseProperties = {
   taxId: {
     type: 'string',
@@ -73,9 +75,9 @@ const companyConfigResponseProperties = {
   },
 } as const;
 
-const errorResponse = {
+const companyConfigObjectSchema = {
   type: 'object',
-  properties: { error: { type: 'string' } },
+  properties: companyConfigResponseProperties,
 } as const;
 
 export const saveCompanyConfigSchema = {
@@ -165,11 +167,10 @@ export const saveCompanyConfigSchema = {
   },
   response: {
     200: {
-      type: 'object',
+      ...successSchema(companyConfigObjectSchema),
       description: 'Configuration saved successfully.',
-      properties: companyConfigResponseProperties,
     },
-    400: { ...errorResponse, description: 'Validation error or missing required fields.' },
+    400: { ...errorResponseSchema, description: 'Validation error or missing required fields.' },
   },
 } as const;
 
@@ -178,10 +179,7 @@ export const getCompanyConfigSchema = {
   summary: 'Get the company fiscal configuration',
   description: 'Returns the current singleton company configuration.',
   response: {
-    200: {
-      type: 'object',
-      properties: companyConfigResponseProperties,
-    },
-    404: { ...errorResponse, description: 'No company configuration has been saved yet.' },
+    200: successSchema(companyConfigObjectSchema),
+    404: { ...errorResponseSchema, description: 'No company configuration has been saved yet.' },
   },
 } as const;

--- a/src/modules/invoice/infra/http/invoice.routes.ts
+++ b/src/modules/invoice/infra/http/invoice.routes.ts
@@ -1,5 +1,7 @@
 import { FastifyInstance } from 'fastify';
 
+import { NotFoundError } from '#/shared/errors/app-error';
+
 import { GetInvoiceQuery, ListInvoicesQuery } from '../../app/queries/invoice.queries';
 import { toDetailResponse, toSummaryResponse } from './invoice.mapper';
 import { getInvoiceSchema, listInvoicesSchema } from './invoice.schemas';
@@ -11,9 +13,9 @@ export interface InvoiceQueries {
 
 export function registerInvoiceRoutes(app: FastifyInstance, queries: InvoiceQueries): void {
   // GET /api/invoices — list all
-  app.get('/api/invoices', { schema: listInvoicesSchema }, async () => {
+  app.get('/api/invoices', { schema: listInvoicesSchema }, async (_request, reply) => {
     const invoices = await queries.list.execute();
-    return invoices.map(toSummaryResponse);
+    return reply.success(invoices.map(toSummaryResponse));
   });
 
   // GET /api/invoices/:id — get by ID
@@ -23,9 +25,9 @@ export function registerInvoiceRoutes(app: FastifyInstance, queries: InvoiceQuer
     async (request, reply) => {
       const invoice = await queries.get.execute(request.params.id);
       if (!invoice) {
-        return reply.status(404).send({ error: 'Invoice not found' });
+        throw new NotFoundError('Invoice not found');
       }
-      return toDetailResponse(invoice);
+      return reply.success(toDetailResponse(invoice));
     },
   );
 }

--- a/src/modules/invoice/infra/http/invoice.schemas.ts
+++ b/src/modules/invoice/infra/http/invoice.schemas.ts
@@ -1,3 +1,5 @@
+import { errorResponseSchema, successSchema } from '#/shared/infra/http/shared-schemas';
+
 const statusHistorySchema = {
   type: 'object',
   description: 'A single status transition recorded on the invoice audit trail.',
@@ -54,19 +56,23 @@ const invoiceDetailProperties = {
   },
 } as const;
 
+const invoiceSummaryObjectSchema = {
+  type: 'object',
+  properties: invoiceSummaryProperties,
+} as const;
+
+const invoiceDetailObjectSchema = {
+  type: 'object',
+  properties: invoiceDetailProperties,
+} as const;
+
 export const listInvoicesSchema = {
   tags: ['Invoices'],
   summary: 'List all invoices',
   description:
     'Returns a summary list of all invoices stored in the system, ordered by creation time. The XML body is omitted from list responses for performance.',
   response: {
-    200: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: invoiceSummaryProperties,
-      },
-    },
+    200: successSchema({ type: 'array', items: invoiceSummaryObjectSchema }),
   },
 } as const;
 
@@ -80,14 +86,7 @@ export const getInvoiceSchema = {
     required: ['id'],
   },
   response: {
-    200: {
-      type: 'object',
-      properties: invoiceDetailProperties,
-    },
-    404: {
-      type: 'object',
-      description: 'No invoice found with the given ID.',
-      properties: { error: { type: 'string', example: 'Invoice not found' } },
-    },
+    200: successSchema(invoiceDetailObjectSchema),
+    404: { ...errorResponseSchema, description: 'No invoice found with the given ID.' },
   },
 } as const;

--- a/src/shared/errors/app-error.ts
+++ b/src/shared/errors/app-error.ts
@@ -1,0 +1,31 @@
+export abstract class AppError extends Error {
+  abstract readonly statusCode: number;
+  abstract readonly code: string;
+
+  constructor(message: string) {
+    super(message);
+    this.name = this.constructor.name;
+    // Required for correct instanceof checks when targeting CommonJS
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class NotFoundError extends AppError {
+  readonly statusCode = 404;
+  readonly code = 'NOT_FOUND';
+}
+
+export class BadRequestError extends AppError {
+  readonly statusCode = 400;
+  readonly code = 'BAD_REQUEST';
+}
+
+export class ValidationError extends AppError {
+  readonly statusCode = 422;
+  readonly code = 'VALIDATION_ERROR';
+}
+
+export class InternalError extends AppError {
+  readonly statusCode = 500;
+  readonly code = 'INTERNAL_ERROR';
+}

--- a/src/shared/infra/http-server.ts
+++ b/src/shared/infra/http-server.ts
@@ -1,9 +1,11 @@
 import fastifyMultipart from '@fastify/multipart';
 import fastifySwagger from '@fastify/swagger';
 import scalarFastify from '@scalar/fastify-api-reference';
+import { randomUUID } from 'crypto';
 import Fastify, { FastifyInstance } from 'fastify';
 
 import { logger } from '../logger';
+import responsePlugin from './http/response.plugin';
 
 export interface HttpServerConfig {
   port: number;
@@ -13,7 +15,12 @@ export interface HttpServerConfig {
 }
 
 export async function createHttpServer(config: HttpServerConfig): Promise<FastifyInstance> {
-  const app = Fastify({ loggerInstance: logger });
+  const app = Fastify({
+    loggerInstance: logger,
+    genReqId: (req) => (req.headers['x-request-id'] as string) ?? randomUUID(),
+  });
+
+  await app.register(responsePlugin);
 
   await app.register(fastifyMultipart, {
     limits: { fileSize: 10 * 1024 * 1024 },

--- a/src/shared/infra/http/fastify-reply.d.ts
+++ b/src/shared/infra/http/fastify-reply.d.ts
@@ -1,0 +1,7 @@
+import 'fastify';
+
+declare module 'fastify' {
+  interface FastifyReply {
+    success(data: unknown): FastifyReply;
+  }
+}

--- a/src/shared/infra/http/response.plugin.ts
+++ b/src/shared/infra/http/response.plugin.ts
@@ -1,0 +1,50 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import fp from 'fastify-plugin';
+
+import { AppError } from '#/shared/errors/app-error';
+import { logger } from '#/shared/logger';
+
+function buildMeta(request: FastifyRequest): { requestId: string; timestamp: string } {
+  return {
+    requestId: request.id as string,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+async function responsePlugin(app: FastifyInstance): Promise<void> {
+  app.decorateReply('success', function (this: FastifyReply, data: unknown) {
+    const meta = buildMeta(this.request);
+    return this.send({ data, meta });
+  });
+
+  app.setErrorHandler(
+    (error: Error & { statusCode?: number; validation?: unknown }, request, reply) => {
+      const meta = buildMeta(request);
+
+      if (error instanceof AppError) {
+        return reply.status(error.statusCode).send({
+          errors: [{ code: error.code, message: error.message }],
+          meta,
+        });
+      }
+
+      // Fastify schema validation errors carry a `validation` array
+      if (error.validation !== undefined) {
+        return reply.status(400).send({
+          errors: [{ code: 'VALIDATION_ERROR', message: error.message }],
+          meta,
+        });
+      }
+
+      // Unknown errors — log and return 500
+      logger.error({ err: error }, 'Unhandled error');
+      return reply.status(500).send({
+        errors: [{ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred' }],
+        meta,
+      });
+    },
+  );
+}
+
+// fp ensures the plugin is not scoped — decorators and error handler apply to the whole app
+export default fp(responsePlugin, { name: 'response-plugin' });

--- a/src/shared/infra/http/shared-schemas.ts
+++ b/src/shared/infra/http/shared-schemas.ts
@@ -1,0 +1,37 @@
+export const metaSchema = {
+  type: 'object',
+  properties: {
+    requestId: { type: 'string' },
+    timestamp: { type: 'string', format: 'date-time' },
+  },
+  required: ['requestId', 'timestamp'],
+} as const;
+
+export const errorItemSchema = {
+  type: 'object',
+  properties: {
+    code: { type: 'string' },
+    message: { type: 'string' },
+  },
+  required: ['code', 'message'],
+} as const;
+
+export const errorResponseSchema = {
+  type: 'object',
+  properties: {
+    errors: { type: 'array', items: errorItemSchema },
+    meta: metaSchema,
+  },
+  required: ['errors', 'meta'],
+} as const;
+
+export function successSchema(dataSchema: object): object {
+  return {
+    type: 'object',
+    properties: {
+      data: dataSchema,
+      meta: metaSchema,
+    },
+    required: ['data', 'meta'],
+  };
+}


### PR DESCRIPTION
  Introduce a consistent { data, meta } success format and
  { errors, meta } error format for all REST endpoints.

  - Add AppError hierarchy (NotFoundError, BadRequestError, ValidationError, InternalError) in src/shared/errors/
  - Add Fastify response plugin with reply.success() decorator and global setErrorHandler
  - Configure genReqId to propagate X-Request-ID header or generate UUID v4; requestId is included in every response
  - Update all route handlers to use reply.success() and throw typed AppErrors instead of manual reply.status().send()
  - Update OpenAPI schemas to document the new envelopes using shared successSchema() and errorResponseSchema helpers
  - Update README with API Response Format section