### PR TITLE
feat: add CORS support via @fastify/cors

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@aws-sdk/lib-dynamodb": "^3.1014.0",
     "@aws-sdk/util-dynamodb": "^3.996.2",
     "@confluentinc/kafka-javascript": "^1.8.0",
+    "@fastify/cors": "^11.2.0",
     "@fastify/multipart": "^9.4.0",
     "@fastify/swagger": "^9.7.0",
     "@scalar/fastify-api-reference": "^1.49.3",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -7,6 +7,7 @@ export interface AppConfig {
   http: {
     port: number;
     host: string;
+    corsOrigins: string[];
   };
   externalServices: {
     sriVoucherWsdl: string;

--- a/src/config/local.ts
+++ b/src/config/local.ts
@@ -9,6 +9,7 @@ export default {
   http: {
     port: 3173,
     host: '0.0.0.0',
+    corsOrigins: (process.env.CORS_ORIGINS || 'http://localhost:5173').split(','),
   },
   externalServices: {
     sriVoucherWsdl:

--- a/src/config/production.ts
+++ b/src/config/production.ts
@@ -9,6 +9,7 @@ export default {
   http: {
     port: Number(process.env.HTTP_PORT) || 3173,
     host: '0.0.0.0',
+    corsOrigins: (process.env.CORS_ORIGINS || '').split(',').filter(Boolean),
   },
   externalServices: {
     sriVoucherWsdl:

--- a/src/container.ts
+++ b/src/container.ts
@@ -170,6 +170,7 @@ export async function createContainer(config: AppConfig) {
   const httpServer = await createHttpServer({
     port: config.http.port,
     host: config.http.host,
+    corsOrigins: config.http.corsOrigins,
     serviceName: config.serviceName,
     serviceVersion: config.serviceVersion,
   });

--- a/src/shared/infra/http-server.ts
+++ b/src/shared/infra/http-server.ts
@@ -1,3 +1,4 @@
+import fastifyCors from '@fastify/cors';
 import fastifyMultipart from '@fastify/multipart';
 import fastifySwagger from '@fastify/swagger';
 import scalarFastify from '@scalar/fastify-api-reference';
@@ -10,6 +11,7 @@ import responsePlugin from './http/response.plugin';
 export interface HttpServerConfig {
   port: number;
   host: string;
+  corsOrigins: string[];
   serviceName: string;
   serviceVersion: string;
 }
@@ -18,6 +20,11 @@ export async function createHttpServer(config: HttpServerConfig): Promise<Fastif
   const app = Fastify({
     loggerInstance: logger,
     genReqId: (req) => (req.headers['x-request-id'] as string) ?? randomUUID(),
+  });
+
+  await app.register(fastifyCors, {
+    origin: config.corsOrigins,
+    methods: ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
   });
 
   await app.register(responsePlugin);


### PR DESCRIPTION
  Enable cross-origin requests by registering @fastify/cors with all
  standard HTTP methods. Allowed origins are configured per environment
  via the CORS_ORIGINS env var (comma-separated).