### PR TITLE
fix: normalize invoice date to Ecuador timezone (UTC-5)

### DIFF
--- a/src/modules/invoice/app/commands/create-invoice.ts
+++ b/src/modules/invoice/app/commands/create-invoice.ts
@@ -22,7 +22,7 @@ export class CreateInvoiceCommand {
     if (!companyConfig.signingCertId)
       throw new Error('No signing certificate configured in company config');
 
-    const date = new Date(message.occurred_at);
+    const date = message.occurred_at;
     const { payload } = message;
 
     const sequenceNum = await this.companyConfigRepository.nextInvoiceSequence();

--- a/src/modules/invoice/app/handlers/sale-confirmed.handler.ts
+++ b/src/modules/invoice/app/handlers/sale-confirmed.handler.ts
@@ -1,7 +1,7 @@
+import { CreateInvoiceCommand } from '../commands/create-invoice';
 import { InvoiceDomainEvent } from '../../domain/events';
 import { MessageProducer } from '../../domain/ports';
 import { SaleConfirmedMessage } from '../../infra/messaging/schemas';
-import { CreateInvoiceCommand } from '../commands/create-invoice';
 
 export class SaleConfirmedHandler {
   constructor(

--- a/src/modules/invoice/domain/invoice-xml-builder.ts
+++ b/src/modules/invoice/domain/invoice-xml-builder.ts
@@ -47,12 +47,13 @@ export function buildInvoiceXml(input: InvoiceXmlInput): string {
 }
 
 function formatDate(d: Date): string {
+  const utcMinus5 = new Date(d.getTime() - 5 * 60 * 60 * 1000);
   return (
-    String(d.getDate()).padStart(2, '0') +
+    String(utcMinus5.getUTCDate()).padStart(2, '0') +
     '/' +
-    String(d.getMonth() + 1).padStart(2, '0') +
+    String(utcMinus5.getUTCMonth() + 1).padStart(2, '0') +
     '/' +
-    String(d.getFullYear())
+    String(utcMinus5.getUTCFullYear())
   );
 }
 

--- a/src/modules/invoice/infra/messaging/schemas.ts
+++ b/src/modules/invoice/infra/messaging/schemas.ts
@@ -56,7 +56,7 @@ export const SaleConfirmedMessageSchema = z.object({
   event_id: z.string().uuid(),
   event_type: z.literal('SaleConfirmed'),
   aggregate_id: z.number(),
-  occurred_at: z.string(),
+  occurred_at: z.string().transform((s) => new Date(s.endsWith('Z') ? s : s + 'Z')),
   payload: SaleConfirmedPayloadSchema,
 });
 


### PR DESCRIPTION
  Parse occurred_at as UTC in the Zod schema and convert to UTC-5
  in formatDate so the invoice XML reflects the correct local date
  regardless of where the service is running.