### PR TITLE
feat: rename orderId to saleId and add GET /api/invoices/by-sale/:saleId

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -27,7 +27,11 @@ import { SendInvoiceCommand } from '#/modules/invoice/app/commands/send-invoice'
 import { SignInvoiceCommand } from '#/modules/invoice/app/commands/sign-invoice';
 import { InvoiceEventHandler } from '#/modules/invoice/app/handlers/invoice-event.handler';
 import { SaleConfirmedHandler } from '#/modules/invoice/app/handlers/sale-confirmed.handler';
-import { GetInvoiceQuery, ListInvoicesQuery } from '#/modules/invoice/app/queries/invoice.queries';
+import {
+  FindInvoicesBySaleIdQuery,
+  GetInvoiceQuery,
+  ListInvoicesQuery,
+} from '#/modules/invoice/app/queries/invoice.queries';
 import { InvoiceStatus } from '#/modules/invoice/domain/invoice';
 import { SignerAdapter } from '#/modules/invoice/infra/adapters/signer.adapter';
 import { SriAuthorizationAdapter } from '#/modules/invoice/infra/adapters/sri-authorization.adapter';
@@ -193,10 +197,12 @@ export async function createContainer(config: AppConfig) {
 
   const getInvoiceQuery = new GetInvoiceQuery(invoiceRepository);
   const listInvoicesQuery = new ListInvoicesQuery(invoiceRepository);
+  const findInvoicesBySaleIdQuery = new FindInvoicesBySaleIdQuery(invoiceRepository);
 
   registerInvoiceRoutes(httpServer, {
     get: getInvoiceQuery,
     list: listInvoicesQuery,
+    findBySaleId: findInvoicesBySaleIdQuery,
   });
 
   await invoiceProducer.connect();

--- a/src/modules/invoice/app/queries/invoice.queries.ts
+++ b/src/modules/invoice/app/queries/invoice.queries.ts
@@ -16,3 +16,11 @@ export class ListInvoicesQuery {
     return this.invoiceRepository.findAll();
   }
 }
+
+export class FindInvoicesBySaleIdQuery {
+  constructor(private readonly invoiceRepository: InvoiceRepository) {}
+
+  async execute(saleId: string): Promise<Invoice[]> {
+    return this.invoiceRepository.findBySaleId(saleId);
+  }
+}

--- a/src/modules/invoice/app/types.ts
+++ b/src/modules/invoice/app/types.ts
@@ -1,7 +1,7 @@
 export interface InvoiceMessageInput {
   type: string;
   invoiceId: string;
-  orderId: string;
+  saleId: string;
   status: string;
   occurredAt: Date;
 }

--- a/src/modules/invoice/domain/events.ts
+++ b/src/modules/invoice/domain/events.ts
@@ -8,7 +8,7 @@ export enum InvoiceStatus {
 
 interface BaseInvoiceEvent {
   invoiceId: string;
-  orderId: string;
+  saleId: string;
   status: InvoiceStatus;
   occurredAt: Date;
 }

--- a/src/modules/invoice/domain/invoice.ts
+++ b/src/modules/invoice/domain/invoice.ts
@@ -20,7 +20,7 @@ export class Invoice {
 
   constructor(
     public readonly id: string = uuidv4(),
-    public readonly orderId: string,
+    public readonly saleId: string,
     public readonly accessCode: AccessCode,
     status: InvoiceStatus,
     public readonly signatureId: string,
@@ -39,15 +39,10 @@ export class Invoice {
     return this._xml;
   }
 
-  static create(
-    orderId: string,
-    accessCode: AccessCode,
-    signatureId: string,
-    xml: string,
-  ): Invoice {
+  static create(saleId: string, accessCode: AccessCode, signatureId: string, xml: string): Invoice {
     const invoice = new Invoice(
       undefined,
-      orderId,
+      saleId,
       accessCode,
       InvoiceStatus.CREATED,
       signatureId,
@@ -98,7 +93,7 @@ export class Invoice {
     this._domainEvents.push({
       type: STATUS_EVENT_TYPE[status],
       invoiceId: this.id,
-      orderId: this.orderId,
+      saleId: this.saleId,
       status,
       occurredAt: date,
     } as InvoiceDomainEvent);

--- a/src/modules/invoice/domain/repository.ts
+++ b/src/modules/invoice/domain/repository.ts
@@ -5,4 +5,5 @@ export interface InvoiceRepository {
   updateInvoice(invoice: Invoice): Promise<Invoice>;
   getInvoiceById(id: string): Promise<Invoice | null>;
   findAll(): Promise<Invoice[]>;
+  findBySaleId(saleId: string): Promise<Invoice[]>;
 }

--- a/src/modules/invoice/infra/http/invoice.mapper.ts
+++ b/src/modules/invoice/infra/http/invoice.mapper.ts
@@ -3,7 +3,7 @@ import { Invoice } from '../../domain/invoice';
 export function toSummaryResponse(invoice: Invoice) {
   return {
     id: invoice.id,
-    orderId: invoice.orderId,
+    saleId: invoice.saleId,
     accessCode: invoice.accessCode.value,
     status: invoice.status,
     signatureId: invoice.signatureId,

--- a/src/modules/invoice/infra/http/invoice.routes.ts
+++ b/src/modules/invoice/infra/http/invoice.routes.ts
@@ -2,13 +2,18 @@ import { FastifyInstance } from 'fastify';
 
 import { NotFoundError } from '#/shared/errors/app-error';
 
-import { GetInvoiceQuery, ListInvoicesQuery } from '../../app/queries/invoice.queries';
+import {
+  FindInvoicesBySaleIdQuery,
+  GetInvoiceQuery,
+  ListInvoicesQuery,
+} from '../../app/queries/invoice.queries';
 import { toDetailResponse, toSummaryResponse } from './invoice.mapper';
-import { getInvoiceSchema, listInvoicesSchema } from './invoice.schemas';
+import { findBySaleIdSchema, getInvoiceSchema, listInvoicesSchema } from './invoice.schemas';
 
 export interface InvoiceQueries {
   get: GetInvoiceQuery;
   list: ListInvoicesQuery;
+  findBySaleId: FindInvoicesBySaleIdQuery;
 }
 
 export function registerInvoiceRoutes(app: FastifyInstance, queries: InvoiceQueries): void {
@@ -17,6 +22,16 @@ export function registerInvoiceRoutes(app: FastifyInstance, queries: InvoiceQuer
     const invoices = await queries.list.execute();
     return reply.success(invoices.map(toSummaryResponse));
   });
+
+  // GET /api/invoices/by-sale/:saleId — find by sale ID
+  app.get<{ Params: { saleId: string } }>(
+    '/api/invoices/by-sale/:saleId',
+    { schema: findBySaleIdSchema },
+    async (request, reply) => {
+      const invoices = await queries.findBySaleId.execute(request.params.saleId);
+      return reply.success(invoices.map(toSummaryResponse));
+    },
+  );
 
   // GET /api/invoices/:id — get by ID
   app.get<{ Params: { id: string } }>(

--- a/src/modules/invoice/infra/http/invoice.schemas.ts
+++ b/src/modules/invoice/infra/http/invoice.schemas.ts
@@ -23,7 +23,7 @@ const statusHistorySchema = {
 
 const invoiceSummaryProperties = {
   id: { type: 'string', format: 'uuid', description: 'Unique invoice identifier.' },
-  orderId: { type: 'string', description: 'Identifier of the originating sale order.' },
+  saleId: { type: 'string', description: 'Identifier of the originating sale.' },
   accessCode: {
     type: 'string',
     description:
@@ -71,6 +71,20 @@ export const listInvoicesSchema = {
   summary: 'List all invoices',
   description:
     'Returns a summary list of all invoices stored in the system, ordered by creation time. The XML body is omitted from list responses for performance.',
+  response: {
+    200: successSchema({ type: 'array', items: invoiceSummaryObjectSchema }),
+  },
+} as const;
+
+export const findBySaleIdSchema = {
+  tags: ['Invoices'],
+  summary: 'Find invoices by sale ID',
+  description: 'Returns all invoices associated with the given sale ID.',
+  params: {
+    type: 'object',
+    properties: { saleId: { type: 'string', description: 'Sale ID.' } },
+    required: ['saleId'],
+  },
   response: {
     200: successSchema({ type: 'array', items: invoiceSummaryObjectSchema }),
   },

--- a/src/modules/invoice/infra/messaging/schemas.ts
+++ b/src/modules/invoice/infra/messaging/schemas.ts
@@ -7,7 +7,7 @@ import { InvoiceStatus } from '../../domain/invoice';
 export const InvoiceMessageSchema = z.object({
   type: z.string(),
   invoiceId: z.string(),
-  orderId: z.string(),
+  saleId: z.string(),
   status: z.nativeEnum(InvoiceStatus),
   occurredAt: z.coerce.date(),
 });

--- a/src/modules/invoice/infra/persistence/dynamo-invoice.repository.ts
+++ b/src/modules/invoice/infra/persistence/dynamo-invoice.repository.ts
@@ -1,4 +1,10 @@
-import { DynamoDBDocumentClient, GetCommand, PutCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  ScanCommand,
+} from '@aws-sdk/lib-dynamodb';
 
 import { Invoice } from '../../domain/invoice';
 import { InvoiceRepository } from '../../domain/repository';
@@ -42,6 +48,18 @@ export class DynamoInvoiceRepository implements InvoiceRepository {
 
   async findAll(): Promise<Invoice[]> {
     const result = await this.docClient.send(new ScanCommand({ TableName: this.tableName }));
+    return (result.Items ?? []).map((item) => fromInvoiceRecord(item as InvoiceRecord));
+  }
+
+  async findBySaleId(saleId: string): Promise<Invoice[]> {
+    const result = await this.docClient.send(
+      new QueryCommand({
+        TableName: this.tableName,
+        IndexName: 'SaleIdIndex',
+        KeyConditionExpression: 'saleId = :saleId',
+        ExpressionAttributeValues: { ':saleId': saleId },
+      }),
+    );
     return (result.Items ?? []).map((item) => fromInvoiceRecord(item as InvoiceRecord));
   }
 }

--- a/src/modules/invoice/infra/persistence/invoice.mapper.ts
+++ b/src/modules/invoice/infra/persistence/invoice.mapper.ts
@@ -3,7 +3,7 @@ import { Invoice, InvoiceStatus, InvoiceStatusHistory } from '../../domain/invoi
 
 export interface InvoiceRecord {
   id: string;
-  orderId: string;
+  saleId: string;
   accessCode: string;
   status: string;
   signatureId: string;
@@ -18,7 +18,7 @@ export interface InvoiceRecord {
 export function toInvoiceRecord(invoice: Invoice): InvoiceRecord {
   return {
     id: invoice.id,
-    orderId: invoice.orderId,
+    saleId: invoice.saleId,
     accessCode: invoice.accessCode.value,
     status: invoice.status,
     signatureId: invoice.signatureId,
@@ -34,7 +34,7 @@ export function toInvoiceRecord(invoice: Invoice): InvoiceRecord {
 export function fromInvoiceRecord(record: InvoiceRecord): Invoice {
   return new Invoice(
     record.id,
-    record.orderId,
+    record.saleId,
     AccessCode.create(record.accessCode),
     record.status as InvoiceStatus,
     record.signatureId,


### PR DESCRIPTION
  Replace  with  across the invoice domain, persistence,
  messaging, and HTTP layers to align with the originating sales.confirmed
  event field. Add  to the repository port backed by a new
  DynamoDB GSI (SaleIdIndex), and expose it via a dedicated endpoint.
  Also remove the unused InvoiceIdIndex GSI from the infra table definition.