### PR TITLE
feat: add retry with exponential backoff and DLQ for Kafka consumer

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -46,6 +46,7 @@ import {
 import { KAFKA_TOPICS } from '#/modules/invoice/infra/messaging/topics';
 import { DynamoInvoiceRepository } from '#/modules/invoice/infra/persistence/dynamo-invoice.repository';
 import { XadesSigner } from '#/modules/invoice/infra/signing/xades-signer';
+import { DlqProducer } from '#/shared/infra/dlq-producer';
 import { createHttpServer } from '#/shared/infra/http-server';
 import { SoapClient } from '#/shared/infra/soap-client';
 
@@ -61,6 +62,7 @@ export async function createContainer(config: AppConfig) {
   const consumer = kafka.consumer({
     kafkaJS: {
       groupId: config.kafka.groupId,
+      autoCommit: false,
     },
   });
   const producer = kafka.producer({
@@ -142,6 +144,9 @@ export async function createContainer(config: AppConfig) {
   );
   const saleConfirmedHandler = new SaleConfirmedHandler(createInvoiceCommand, invoiceProducer);
 
+  // DLQ
+  const dlqProducer = new DlqProducer(producer, KAFKA_TOPICS.DLQ, config.kafka.groupId);
+
   // Consumer
   const kafkaConsumer = new InvoiceKafkaConsumer(
     consumer,
@@ -156,6 +161,7 @@ export async function createContainer(config: AppConfig) {
         validator: SaleConfirmedMessageSchema,
       },
     },
+    dlqProducer,
   );
 
   // Certificate module

--- a/src/modules/invoice/app/handlers/sale-confirmed.handler.ts
+++ b/src/modules/invoice/app/handlers/sale-confirmed.handler.ts
@@ -1,7 +1,7 @@
-import { CreateInvoiceCommand } from '../commands/create-invoice';
 import { InvoiceDomainEvent } from '../../domain/events';
 import { MessageProducer } from '../../domain/ports';
 import { SaleConfirmedMessage } from '../../infra/messaging/schemas';
+import { CreateInvoiceCommand } from '../commands/create-invoice';
 
 export class SaleConfirmedHandler {
   constructor(

--- a/src/modules/invoice/infra/messaging/kafka-consumer.ts
+++ b/src/modules/invoice/infra/messaging/kafka-consumer.ts
@@ -1,7 +1,9 @@
 import { KafkaJS } from '@confluentinc/kafka-javascript';
 import { ZodSchema } from 'zod';
 
-import { BaseKafkaConsumer } from '#/shared/infra/kafka';
+import { NonRetryableError } from '#/shared/errors/non-retryable.error';
+import { DlqProducer } from '#/shared/infra/dlq-producer';
+import { BaseKafkaConsumer, RetryConfig } from '#/shared/infra/kafka';
 import { logger } from '#/shared/logger';
 
 interface MessageProcessor {
@@ -13,25 +15,33 @@ export class InvoiceKafkaConsumer extends BaseKafkaConsumer {
     consumer: KafkaJS.Consumer,
     topics: string[],
     private processors: Record<string, { handler: MessageProcessor; validator: ZodSchema }>,
+    dlqProducer: DlqProducer,
+    retryConfig?: Partial<RetryConfig>,
   ) {
-    super(consumer, topics);
+    super(consumer, topics, dlqProducer, retryConfig);
   }
 
   protected async handleMessage(topic: string, message: string): Promise<void> {
     const processor = this.processors[topic];
     if (!processor) {
-      logger.warn({ topic }, 'No processor defined for topic');
-      return;
+      throw new NonRetryableError(`No processor defined for topic: ${topic}`);
     }
 
-    const parsed = JSON.parse(message);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(message);
+    } catch {
+      throw new NonRetryableError(`Invalid JSON in message from topic: ${topic}`);
+    }
+
     const result = processor.validator.safeParse(parsed);
 
     if (!result.success) {
-      logger.error({ topic, issues: result.error.issues }, 'Invalid message schema, skipping');
-      return;
+      const issues = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+      throw new NonRetryableError(`Invalid message schema on topic ${topic}: ${issues}`);
     }
 
+    logger.debug({ topic }, 'Message validated, dispatching to handler');
     await processor.handler.handle(result.data);
   }
 }

--- a/src/modules/invoice/infra/messaging/topics.ts
+++ b/src/modules/invoice/infra/messaging/topics.ts
@@ -1,4 +1,5 @@
 export enum KAFKA_TOPICS {
   INVOICES = 'invoices',
   SALES_CONFIRMED = 'sales.confirmed',
+  DLQ = 'dlq',
 }

--- a/src/shared/errors/non-retryable.error.ts
+++ b/src/shared/errors/non-retryable.error.ts
@@ -1,0 +1,10 @@
+export class NonRetryableError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: Error,
+  ) {
+    super(message);
+    this.name = 'NonRetryableError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/src/shared/infra/dlq-producer.ts
+++ b/src/shared/infra/dlq-producer.ts
@@ -1,0 +1,73 @@
+import { KafkaJS } from '@confluentinc/kafka-javascript';
+
+import { logger } from '../logger';
+
+interface DlqEnvelope {
+  originalTopic: string;
+  originalPartition: number;
+  originalOffset: string;
+  originalKey: string | null;
+  originalValue: string;
+  originalTimestamp: string | null;
+  errorMessage: string;
+  errorType: 'NON_RETRYABLE' | 'MAX_RETRIES_EXHAUSTED';
+  retriesAttempted: number;
+  consumerGroupId: string;
+  failedAt: string;
+}
+
+export interface DlqMessageContext {
+  topic: string;
+  partition: number;
+  offset: string;
+  key: string | null;
+  value: string;
+  timestamp: string | null;
+}
+
+export class DlqProducer {
+  constructor(
+    private producer: KafkaJS.Producer,
+    private dlqTopic: string,
+    private consumerGroupId: string,
+  ) {}
+
+  async send(
+    context: DlqMessageContext,
+    error: Error,
+    errorType: 'NON_RETRYABLE' | 'MAX_RETRIES_EXHAUSTED',
+    retriesAttempted: number,
+  ): Promise<void> {
+    const envelope: DlqEnvelope = {
+      originalTopic: context.topic,
+      originalPartition: context.partition,
+      originalOffset: context.offset,
+      originalKey: context.key,
+      originalValue: context.value,
+      originalTimestamp: context.timestamp,
+      errorMessage: error.message,
+      errorType,
+      retriesAttempted,
+      consumerGroupId: this.consumerGroupId,
+      failedAt: new Date().toISOString(),
+    };
+
+    const key = `${context.topic}:${context.partition}:${context.offset}`;
+
+    await this.producer.send({
+      topic: this.dlqTopic,
+      messages: [{ key, value: JSON.stringify(envelope) }],
+    });
+
+    logger.warn(
+      {
+        dlqTopic: this.dlqTopic,
+        originalTopic: context.topic,
+        originalOffset: context.offset,
+        errorType,
+        errorMessage: error.message,
+      },
+      'Message sent to DLQ',
+    );
+  }
+}

--- a/src/shared/infra/kafka.ts
+++ b/src/shared/infra/kafka.ts
@@ -1,12 +1,45 @@
 import { KafkaJS } from '@confluentinc/kafka-javascript';
 
+import { BadRequestError, ValidationError } from '../errors/app-error';
+import { NonRetryableError } from '../errors/non-retryable.error';
 import { logger } from '../logger';
+import { DlqMessageContext, DlqProducer } from './dlq-producer';
+
+export interface RetryConfig {
+  maxRetries: number;
+  baseDelayMs: number;
+}
+
+const DEFAULT_RETRY_CONFIG: RetryConfig = { maxRetries: 3, baseDelayMs: 1000 };
+
+function isRetryable(error: unknown): boolean {
+  if (error instanceof NonRetryableError) return false;
+  if (error instanceof BadRequestError) return false;
+  if (error instanceof ValidationError) return false;
+  return true;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function calculateBackoff(attempt: number, baseDelayMs: number): number {
+  const delay = baseDelayMs * Math.pow(2, attempt);
+  const jitter = 0.75 + Math.random() * 0.5;
+  return delay * jitter;
+}
 
 export abstract class BaseKafkaConsumer {
+  private retryConfig: RetryConfig;
+
   constructor(
     private consumer: KafkaJS.Consumer,
     private topics: string[],
-  ) {}
+    private dlqProducer: DlqProducer,
+    retryConfig?: Partial<RetryConfig>,
+  ) {
+    this.retryConfig = { ...DEFAULT_RETRY_CONFIG, ...retryConfig };
+  }
 
   protected abstract handleMessage(topic: string, message: string): Promise<void>;
 
@@ -16,29 +49,77 @@ export abstract class BaseKafkaConsumer {
 
     await this.consumer.run({
       eachMessage: async ({ topic, partition, message }) => {
-        if (message.value) {
-          const value = message.value.toString();
-          logger.debug(
-            {
-              topic,
-              partition,
-              offset: message.offset,
-              key: message.key?.toString(),
-              size: value.length,
-            },
-            'Kafka message received',
-          );
-          try {
-            await this.handleMessage(topic, value);
-          } catch (error) {
-            logger.error(
-              { topic, partition, offset: message.offset, err: error },
-              'Failed to process message, skipping',
-            );
-          }
-        }
+        if (!message.value) return;
+
+        const value = message.value.toString();
+        logger.debug(
+          {
+            topic,
+            partition,
+            offset: message.offset,
+            key: message.key?.toString(),
+            size: value.length,
+          },
+          'Kafka message received',
+        );
+
+        const dlqContext: DlqMessageContext = {
+          topic,
+          partition,
+          offset: message.offset,
+          key: message.key?.toString() ?? null,
+          value,
+          timestamp: message.timestamp ?? null,
+        };
+
+        await this.processWithRetry(topic, value, dlqContext);
+
+        await this.consumer.commitOffsets([
+          { topic, partition, offset: (BigInt(message.offset) + 1n).toString() },
+        ]);
       },
     });
+  }
+
+  private async processWithRetry(
+    topic: string,
+    value: string,
+    dlqContext: DlqMessageContext,
+  ): Promise<void> {
+    const { maxRetries, baseDelayMs } = this.retryConfig;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        await this.handleMessage(topic, value);
+        return;
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+
+        if (!isRetryable(error)) {
+          logger.error(
+            { topic, offset: dlqContext.offset, err, attempt },
+            'Non-retryable error, sending to DLQ',
+          );
+          await this.dlqProducer.send(dlqContext, err, 'NON_RETRYABLE', attempt);
+          return;
+        }
+
+        if (attempt < maxRetries) {
+          const backoff = calculateBackoff(attempt, baseDelayMs);
+          logger.warn(
+            { topic, offset: dlqContext.offset, err, attempt: attempt + 1, maxRetries, backoff },
+            'Retryable error, retrying after backoff',
+          );
+          await sleep(backoff);
+        } else {
+          logger.error(
+            { topic, offset: dlqContext.offset, err, retriesAttempted: maxRetries },
+            'Max retries exhausted, sending to DLQ',
+          );
+          await this.dlqProducer.send(dlqContext, err, 'MAX_RETRIES_EXHAUSTED', maxRetries);
+        }
+      }
+    }
   }
 
   async stop(): Promise<void> {


### PR DESCRIPTION
  Prevent message loss on processing errors by retrying up to 3 times
  with exponential backoff (1s, 2s, 4s) and routing failed messages to
  a dead-letter queue topic. Switch to manual offset commits so offsets
  are only committed after successful processing or DLQ delivery.